### PR TITLE
golint fixed

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -25,6 +25,7 @@ func (b *Blob) Data() (io.Reader, error) {
 	return bytes.NewBuffer(stdout), nil
 }
 
+// DataPipeline gets content of blob and write the result or error to stdout or stderr
 func (b *Blob) DataPipeline(stdout, stderr io.Writer) error {
 	return NewCommand("show", b.ID.String()).RunInDirPipeline(b.repo.Path, stdout, stderr)
 }

--- a/command.go
+++ b/command.go
@@ -40,13 +40,11 @@ func (c *Command) AddArguments(args ...string) *Command {
 	return c
 }
 
-const DEFAULT_TIMEOUT = 60 * time.Second
-
 // RunInDirTimeoutPipeline executes the command in given directory with given timeout,
 // it pipes stdout and stderr to given io.Writer.
 func (c *Command) RunInDirTimeoutPipeline(timeout time.Duration, dir string, stdout, stderr io.Writer) error {
 	if timeout == -1 {
-		timeout = DEFAULT_TIMEOUT
+		timeout = 60 * time.Second
 	}
 
 	if len(dir) == 0 {
@@ -106,7 +104,7 @@ func (c *Command) RunInDirPipeline(dir string, stdout, stderr io.Writer) error {
 	return c.RunInDirTimeoutPipeline(-1, dir, stdout, stderr)
 }
 
-// RunInDir executes the command in given directory
+// RunInDirBytes executes the command in given directory
 // and returns stdout in []byte and error (combined with stderr).
 func (c *Command) RunInDirBytes(dir string) ([]byte, error) {
 	return c.RunInDirTimeout(-1, dir)

--- a/commit.go
+++ b/commit.go
@@ -18,13 +18,13 @@ import (
 // Commit represents a git commit.
 type Commit struct {
 	Tree
-	ID            sha1 // The ID of this commit object
+	ID            SHA1 // The ID of this commit object
 	Author        *Signature
 	Committer     *Signature
 	CommitMessage string
 
-	parents        []sha1 // SHA1 strings
-	submoduleCache *objectCache
+	parents        []SHA1 // SHA1 strings
+	submoduleCache *ObjectCache
 }
 
 // Message returns the commit message. Same as retrieving CommitMessage directly.
@@ -39,9 +39,9 @@ func (c *Commit) Summary() string {
 
 // ParentID returns oid of n-th parent (0-based index).
 // It returns nil if no such parent exists.
-func (c *Commit) ParentID(n int) (sha1, error) {
+func (c *Commit) ParentID(n int) (SHA1, error) {
 	if n >= len(c.parents) {
-		return sha1{}, ErrNotExist{"", ""}
+		return SHA1{}, ErrNotExist{"", ""}
 	}
 	return c.parents[n], nil
 }
@@ -208,7 +208,7 @@ func (c *Commit) GetFilesChangedSinceCommit(pastCommit string) ([]string, error)
 }
 
 // GetSubModules get all the sub modules of current revision git tree
-func (c *Commit) GetSubModules() (*objectCache, error) {
+func (c *Commit) GetSubModules() (*ObjectCache, error) {
 	if c.submoduleCache != nil {
 		return c.submoduleCache, nil
 	}

--- a/commit.go
+++ b/commit.go
@@ -73,6 +73,7 @@ func isImageFile(data []byte) (string, bool) {
 	return contentType, false
 }
 
+// IsImageFile is a file image type
 func (c *Commit) IsImageFile(name string) bool {
 	blob, err := c.GetBlobByPath(name)
 	if err != nil {
@@ -95,7 +96,7 @@ func (c *Commit) GetCommitByPath(relpath string) (*Commit, error) {
 	return c.repo.getCommitByPathWithID(c.ID, relpath)
 }
 
-// AddAllChanges marks local changes to be ready for commit.
+// AddChanges marks local changes to be ready for commit.
 func AddChanges(repoPath string, all bool, files ...string) error {
 	cmd := NewCommand("add")
 	if all {
@@ -105,6 +106,7 @@ func AddChanges(repoPath string, all bool, files ...string) error {
 	return err
 }
 
+// CommitChangesOptions the options when a commit created
 type CommitChangesOptions struct {
 	Committer *Signature
 	Author    *Signature
@@ -166,22 +168,27 @@ func CommitsCount(repoPath, revision string) (int64, error) {
 	return commitsCount(repoPath, revision, "")
 }
 
+// CommitsCount returns number of total commits of until current revision.
 func (c *Commit) CommitsCount() (int64, error) {
 	return CommitsCount(c.repo.Path, c.ID.String())
 }
 
+// CommitsByRange returns the specific page commits before current revision, every page's number default by CommitsRangeSize
 func (c *Commit) CommitsByRange(page int) (*list.List, error) {
 	return c.repo.commitsByRange(c.ID, page)
 }
 
+// CommitsBefore returns all the commits before current revision
 func (c *Commit) CommitsBefore() (*list.List, error) {
 	return c.repo.getCommitsBefore(c.ID)
 }
 
+// CommitsBeforeLimit returns num commits before current revision
 func (c *Commit) CommitsBeforeLimit(num int) (*list.List, error) {
 	return c.repo.getCommitsBeforeLimit(c.ID, num)
 }
 
+// CommitsBeforeUntil returns the commits between commitID to current revision
 func (c *Commit) CommitsBeforeUntil(commitID string) (*list.List, error) {
 	endCommit, err := c.repo.GetCommit(commitID)
 	if err != nil {
@@ -190,14 +197,17 @@ func (c *Commit) CommitsBeforeUntil(commitID string) (*list.List, error) {
 	return c.repo.CommitsBetween(c, endCommit)
 }
 
+// SearchCommits returns the commits match the keyword before current revision
 func (c *Commit) SearchCommits(keyword string) (*list.List, error) {
 	return c.repo.searchCommits(c.ID, keyword)
 }
 
+// GetFilesChangedSinceCommit get all changed file names between pastCommit to current revision
 func (c *Commit) GetFilesChangedSinceCommit(pastCommit string) ([]string, error) {
 	return c.repo.getFilesChanged(pastCommit, c.ID.String())
 }
 
+// GetSubModules get all the sub modules of current revision git tree
 func (c *Commit) GetSubModules() (*objectCache, error) {
 	if c.submoduleCache != nil {
 		return c.submoduleCache, nil
@@ -236,6 +246,7 @@ func (c *Commit) GetSubModules() (*objectCache, error) {
 	return c.submoduleCache, nil
 }
 
+// GetSubModule get the sub module according entryname
 func (c *Commit) GetSubModule(entryname string) (*SubModule, error) {
 	modules, err := c.GetSubModules()
 	if err != nil {

--- a/commit_archive.go
+++ b/commit_archive.go
@@ -10,13 +10,17 @@ import (
 	"strings"
 )
 
+// ArchiveType archive types
 type ArchiveType int
 
 const (
+	// ZIP zip archive type
 	ZIP ArchiveType = iota + 1
+	// TARGZ tar gz archive type
 	TARGZ
 )
 
+// CreateArchive create archive content to the target path
 func (c *Commit) CreateArchive(target string, archiveType ArchiveType) error {
 	var format string
 	switch archiveType {

--- a/error.go
+++ b/error.go
@@ -9,10 +9,12 @@ import (
 	"time"
 )
 
+// ErrExecTimeout error when exec timed out
 type ErrExecTimeout struct {
 	Duration time.Duration
 }
 
+// IsErrExecTimeout if some error is ErrExecTimeout
 func IsErrExecTimeout(err error) bool {
 	_, ok := err.(ErrExecTimeout)
 	return ok
@@ -22,11 +24,13 @@ func (err ErrExecTimeout) Error() string {
 	return fmt.Sprintf("execution is timeout [duration: %v]", err.Duration)
 }
 
+// ErrNotExist commit not exist error
 type ErrNotExist struct {
 	ID      string
 	RelPath string
 }
 
+// IsErrNotExist if some error is ErrNotExist
 func IsErrNotExist(err error) bool {
 	_, ok := err.(ErrNotExist)
 	return ok
@@ -36,10 +40,12 @@ func (err ErrNotExist) Error() string {
 	return fmt.Sprintf("object does not exist [id: %s, rel_path: %s]", err.ID, err.RelPath)
 }
 
+// ErrUnsupportedVersion error when required git version not matched
 type ErrUnsupportedVersion struct {
 	Required string
 }
 
+// IsErrUnsupportedVersion if some error is ErrUnsupportedVersion
 func IsErrUnsupportedVersion(err error) bool {
 	_, ok := err.(ErrUnsupportedVersion)
 	return ok

--- a/git.go
+++ b/git.go
@@ -10,16 +10,16 @@ import (
 	"time"
 )
 
-const _VERSION = "0.4.2"
-
+// Version return this package's current version
 func Version() string {
-	return _VERSION
+	return "0.4.2"
 }
 
 var (
 	// Debug enables verbose logging on everything.
 	// This should be false in case Gogs starts in SSH mode.
-	Debug  = false
+	Debug = false
+	// Prefix the log prefix
 	Prefix = "[git-module] "
 )
 
@@ -38,7 +38,7 @@ func log(format string, args ...interface{}) {
 
 var gitVersion string
 
-// Version returns current Git version from shell.
+// BinVersion returns current Git version from shell.
 func BinVersion() (string, error) {
 	if len(gitVersion) > 0 {
 		return gitVersion, nil

--- a/hook.go
+++ b/hook.go
@@ -104,6 +104,7 @@ func ListHooks(repoPath string) (_ []*Hook, err error) {
 }
 
 const (
+	// HookPathUpdate hook update path
 	HookPathUpdate = "hooks/update"
 )
 

--- a/hook.go
+++ b/hook.go
@@ -22,6 +22,7 @@ var hookNames = []string{
 }
 
 var (
+	// ErrNotValidHook error when a git hook is not valid
 	ErrNotValidHook = errors.New("not a valid Git hook")
 )
 
@@ -70,6 +71,7 @@ func GetHook(repoPath, name string) (*Hook, error) {
 	return h, nil
 }
 
+// Name return the name of the hook
 func (h *Hook) Name() string {
 	return h.name
 }

--- a/repo.go
+++ b/repo.go
@@ -18,8 +18,8 @@ import (
 type Repository struct {
 	Path string
 
-	commitCache *objectCache
-	tagCache    *objectCache
+	commitCache *ObjectCache
+	tagCache    *ObjectCache
 }
 
 const prettyLogFormat = `--pretty=format:%H`

--- a/repo.go
+++ b/repo.go
@@ -22,7 +22,7 @@ type Repository struct {
 	tagCache    *objectCache
 }
 
-const _PRETTY_LOG_FORMAT = `--pretty=format:%H`
+const prettyLogFormat = `--pretty=format:%H`
 
 func (repo *Repository) parsePrettyFormatLogToList(logs []byte) (*list.List, error) {
 	l := list.New()
@@ -32,8 +32,8 @@ func (repo *Repository) parsePrettyFormatLogToList(logs []byte) (*list.List, err
 
 	parts := bytes.Split(logs, []byte{'\n'})
 
-	for _, commitId := range parts {
-		commit, err := repo.GetCommit(string(commitId))
+	for _, commitID := range parts {
+		commit, err := repo.GetCommit(string(commitID))
 		if err != nil {
 			return nil, err
 		}
@@ -80,6 +80,7 @@ func OpenRepository(repoPath string) (*Repository, error) {
 	}, nil
 }
 
+// CloneRepoOptions options when clone a repository
 type CloneRepoOptions struct {
 	Timeout time.Duration
 	Mirror  bool
@@ -118,6 +119,7 @@ func Clone(from, to string, opts CloneRepoOptions) (err error) {
 	return err
 }
 
+// PullRemoteOptions options when pull from remote
 type PullRemoteOptions struct {
 	Timeout time.Duration
 	All     bool
@@ -153,6 +155,7 @@ func Push(repoPath, remote, branch string) error {
 	return err
 }
 
+// CheckoutOptions options when heck out some branch
 type CheckoutOptions struct {
 	Timeout   time.Duration
 	Branch    string

--- a/repo_branch.go
+++ b/repo_branch.go
@@ -11,7 +11,8 @@ import (
 	"github.com/mcuadros/go-version"
 )
 
-const BRANCH_PREFIX = "refs/heads/"
+// BranchPrefix base dir of the branch information file store on git
+const BranchPrefix = "refs/heads/"
 
 // IsReferenceExist returns true if given reference exists in the repository.
 func IsReferenceExist(repoPath, name string) bool {
@@ -21,9 +22,10 @@ func IsReferenceExist(repoPath, name string) bool {
 
 // IsBranchExist returns true if given branch exists in the repository.
 func IsBranchExist(repoPath, name string) bool {
-	return IsReferenceExist(repoPath, BRANCH_PREFIX+name)
+	return IsReferenceExist(repoPath, BranchPrefix+name)
 }
 
+// IsBranchExist returns true if given branch exists in current repository.
 func (repo *Repository) IsBranchExist(name string) bool {
 	return IsBranchExist(repo.Path, name)
 }
@@ -42,12 +44,12 @@ func (repo *Repository) GetHEADBranch() (*Branch, error) {
 	}
 	stdout = strings.TrimSpace(stdout)
 
-	if !strings.HasPrefix(stdout, BRANCH_PREFIX) {
+	if !strings.HasPrefix(stdout, BranchPrefix) {
 		return nil, fmt.Errorf("invalid HEAD branch: %v", stdout)
 	}
 
 	return &Branch{
-		Name: stdout[len(BRANCH_PREFIX):],
+		Name: stdout[len(BranchPrefix):],
 		Path: stdout,
 	}, nil
 }
@@ -58,7 +60,7 @@ func (repo *Repository) SetDefaultBranch(name string) error {
 		return ErrUnsupportedVersion{"1.7.10"}
 	}
 
-	_, err := NewCommand("symbolic-ref", "HEAD", BRANCH_PREFIX+name).RunInDir(repo.Path)
+	_, err := NewCommand("symbolic-ref", "HEAD", BranchPrefix+name).RunInDir(repo.Path)
 	return err
 }
 
@@ -76,12 +78,12 @@ func (repo *Repository) GetBranches() ([]string, error) {
 		if len(fields) != 2 {
 			continue // NOTE: I should believe git will not give me wrong string.
 		}
-		branches[i] = strings.TrimPrefix(fields[1], BRANCH_PREFIX)
+		branches[i] = strings.TrimPrefix(fields[1], BranchPrefix)
 	}
 	return branches, nil
 }
 
-// Option(s) for delete branch
+// DeleteBranchOptions Option(s) for delete branch
 type DeleteBranchOptions struct {
 	Force bool
 }

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -41,7 +41,7 @@ func (repo *Repository) GetTagCommitID(name string) (string, error) {
 // \n\n separate headers from message
 func parseCommitData(data []byte) (*Commit, error) {
 	commit := new(Commit)
-	commit.parents = make([]sha1, 0, 1)
+	commit.parents = make([]SHA1, 0, 1)
 	// we now have the contents of the commit object. Let's investigate...
 	nextline := 0
 l:
@@ -90,7 +90,7 @@ l:
 	return commit, nil
 }
 
-func (repo *Repository) getCommit(id sha1) (*Commit, error) {
+func (repo *Repository) getCommit(id SHA1) (*Commit, error) {
 	c, ok := repo.commitCache.Get(id.String())
 	if ok {
 		log("Hit cache: %s", id)
@@ -151,7 +151,7 @@ func (repo *Repository) GetTagCommit(name string) (*Commit, error) {
 	return repo.GetCommit(commitID)
 }
 
-func (repo *Repository) getCommitByPathWithID(id sha1, relpath string) (*Commit, error) {
+func (repo *Repository) getCommitByPathWithID(id SHA1, relpath string) (*Commit, error) {
 	// File name starts with ':' must be escaped.
 	if relpath[0] == ':' {
 		relpath = `\` + relpath
@@ -187,7 +187,7 @@ func (repo *Repository) GetCommitByPath(relpath string) (*Commit, error) {
 // CommitsRangeSize the default commits range size
 var CommitsRangeSize = 50
 
-func (repo *Repository) commitsByRange(id sha1, page int) (*list.List, error) {
+func (repo *Repository) commitsByRange(id SHA1, page int) (*list.List, error) {
 	stdout, err := NewCommand("log", id.String(), "--skip="+strconv.Itoa((page-1)*CommitsRangeSize),
 		"--max-count="+strconv.Itoa(CommitsRangeSize), prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
@@ -196,7 +196,7 @@ func (repo *Repository) commitsByRange(id sha1, page int) (*list.List, error) {
 	return repo.parsePrettyFormatLogToList(stdout)
 }
 
-func (repo *Repository) searchCommits(id sha1, keyword string) (*list.List, error) {
+func (repo *Repository) searchCommits(id SHA1, keyword string) (*list.List, error) {
 	stdout, err := NewCommand("log", id.String(), "-100", "-i", "--grep="+keyword, prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
 }
 
 // commitsBefore the limit is depth, not total number of returned commits.
-func (repo *Repository) commitsBefore(l *list.List, parent *list.Element, id sha1, current, limit int) error {
+func (repo *Repository) commitsBefore(l *list.List, parent *list.Element, id SHA1, current, limit int) error {
 	// Reach the limit
 	if limit > 0 && current > limit {
 		return nil
@@ -349,12 +349,12 @@ func (repo *Repository) commitsBefore(l *list.List, parent *list.Element, id sha
 	return nil
 }
 
-func (repo *Repository) getCommitsBefore(id sha1) (*list.List, error) {
+func (repo *Repository) getCommitsBefore(id SHA1) (*list.List, error) {
 	l := list.New()
 	return l, repo.commitsBefore(l, nil, id, 1, 0)
 }
 
-func (repo *Repository) getCommitsBeforeLimit(id sha1, num int) (*list.List, error) {
+func (repo *Repository) getCommitsBeforeLimit(id SHA1, num int) (*list.List, error) {
 	l := list.New()
 	return l, repo.commitsBefore(l, nil, id, 1, num)
 }

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -28,12 +28,12 @@ func (repo *Repository) getRefCommitID(name string) (string, error) {
 
 // GetBranchCommitID returns last commit ID string of given branch.
 func (repo *Repository) GetBranchCommitID(name string) (string, error) {
-	return repo.getRefCommitID(BRANCH_PREFIX + name)
+	return repo.getRefCommitID(BranchPrefix + name)
 }
 
 // GetTagCommitID returns last commit ID string of given tag.
 func (repo *Repository) GetTagCommitID(name string) (string, error) {
-	return repo.getRefCommitID(TAG_PREFIX + name)
+	return repo.getRefCommitID(TagPrefix + name)
 }
 
 // parseCommitData parses commit information from the (uncompressed) raw
@@ -142,6 +142,7 @@ func (repo *Repository) GetBranchCommit(name string) (*Commit, error) {
 	return repo.GetCommit(commitID)
 }
 
+// GetTagCommit get the commit of the specific tag via name
 func (repo *Repository) GetTagCommit(name string) (*Commit, error) {
 	commitID, err := repo.GetTagCommitID(name)
 	if err != nil {
@@ -156,7 +157,7 @@ func (repo *Repository) getCommitByPathWithID(id sha1, relpath string) (*Commit,
 		relpath = `\` + relpath
 	}
 
-	stdout, err := NewCommand("log", "-1", _PRETTY_LOG_FORMAT, id.String(), "--", relpath).RunInDir(repo.Path)
+	stdout, err := NewCommand("log", "-1", prettyLogFormat, id.String(), "--", relpath).RunInDir(repo.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +172,7 @@ func (repo *Repository) getCommitByPathWithID(id sha1, relpath string) (*Commit,
 
 // GetCommitByPath returns the last commit of relative path.
 func (repo *Repository) GetCommitByPath(relpath string) (*Commit, error) {
-	stdout, err := NewCommand("log", "-1", _PRETTY_LOG_FORMAT, "--", relpath).RunInDirBytes(repo.Path)
+	stdout, err := NewCommand("log", "-1", prettyLogFormat, "--", relpath).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -183,11 +184,12 @@ func (repo *Repository) GetCommitByPath(relpath string) (*Commit, error) {
 	return commits.Front().Value.(*Commit), nil
 }
 
+// CommitsRangeSize the default commits range size
 var CommitsRangeSize = 50
 
 func (repo *Repository) commitsByRange(id sha1, page int) (*list.List, error) {
 	stdout, err := NewCommand("log", id.String(), "--skip="+strconv.Itoa((page-1)*CommitsRangeSize),
-		"--max-count="+strconv.Itoa(CommitsRangeSize), _PRETTY_LOG_FORMAT).RunInDirBytes(repo.Path)
+		"--max-count="+strconv.Itoa(CommitsRangeSize), prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +197,7 @@ func (repo *Repository) commitsByRange(id sha1, page int) (*list.List, error) {
 }
 
 func (repo *Repository) searchCommits(id sha1, keyword string) (*list.List, error) {
-	stdout, err := NewCommand("log", id.String(), "-100", "-i", "--grep="+keyword, _PRETTY_LOG_FORMAT).RunInDirBytes(repo.Path)
+	stdout, err := NewCommand("log", id.String(), "-100", "-i", "--grep="+keyword, prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -210,19 +212,22 @@ func (repo *Repository) getFilesChanged(id1 string, id2 string) ([]string, error
 	return strings.Split(string(stdout), "\n"), nil
 }
 
+// FileCommitsCount return the number of files at a revison
 func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
 	return commitsCount(repo.Path, revision, file)
 }
 
+// CommitsByFileAndRange return the commits accroding revison file and the page
 func (repo *Repository) CommitsByFileAndRange(revision, file string, page int) (*list.List, error) {
 	stdout, err := NewCommand("log", revision, "--skip="+strconv.Itoa((page-1)*50),
-		"--max-count="+strconv.Itoa(CommitsRangeSize), _PRETTY_LOG_FORMAT, "--", file).RunInDirBytes(repo.Path)
+		"--max-count="+strconv.Itoa(CommitsRangeSize), prettyLogFormat, "--", file).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
 	}
 	return repo.parsePrettyFormatLogToList(stdout)
 }
 
+// FilesCountBetween return the number of files changed between two commits
 func (repo *Repository) FilesCountBetween(startCommitID, endCommitID string) (int, error) {
 	stdout, err := NewCommand("diff", "--name-only", startCommitID+"..."+endCommitID).RunInDir(repo.Path)
 	if err != nil {
@@ -266,6 +271,7 @@ func (repo *Repository) CommitsBetween(last *Commit, before *Commit) (*list.List
 	return l, nil
 }
 
+// CommitsBetweenIDs return commits between twoe commits
 func (repo *Repository) CommitsBetweenIDs(last, before string) (*list.List, error) {
 	lastCommit, err := repo.GetCommit(last)
 	if err != nil {
@@ -278,11 +284,12 @@ func (repo *Repository) CommitsBetweenIDs(last, before string) (*list.List, erro
 	return repo.CommitsBetween(lastCommit, beforeCommit)
 }
 
+// CommitsCountBetween return numbers of commits between two commits
 func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
 	return commitsCount(repo.Path, start+"..."+end, "")
 }
 
-// The limit is depth, not total number of returned commits.
+// commitsBefore the limit is depth, not total number of returned commits.
 func (repo *Repository) commitsBefore(l *list.List, parent *list.Element, id sha1, current, limit int) error {
 	// Reach the limit
 	if limit > 0 && current > limit {

--- a/repo_hook.go
+++ b/repo_hook.go
@@ -4,10 +4,12 @@
 
 package git
 
+// GetHook get one hook accroding the name on a repository
 func (repo *Repository) GetHook(name string) (*Hook, error) {
 	return GetHook(repo.Path, name)
 }
 
+// Hooks get all the hooks on the repository
 func (repo *Repository) Hooks() ([]*Hook, error) {
 	return ListHooks(repo.Path)
 }

--- a/repo_object.go
+++ b/repo_object.go
@@ -4,11 +4,16 @@
 
 package git
 
+// ObjectType git object type
 type ObjectType string
 
 const (
-	OBJECT_COMMIT ObjectType = "commit"
-	OBJECT_TREE   ObjectType = "tree"
-	OBJECT_BLOB   ObjectType = "blob"
-	OBJECT_TAG    ObjectType = "tag"
+	// ObjectCommit commit object type
+	ObjectCommit ObjectType = "commit"
+	// ObjectTree tree object type
+	ObjectTree ObjectType = "tree"
+	// ObjectBlob blob object type
+	ObjectBlob ObjectType = "blob"
+	// ObjectTag tag object type
+	ObjectTag ObjectType = "tag"
 )

--- a/repo_pull.go
+++ b/repo_pull.go
@@ -50,7 +50,7 @@ func (repo *Repository) GetPullRequestInfo(basePath, baseBranch, headBranch stri
 		return nil, fmt.Errorf("GetMergeBase: %v", err)
 	}
 
-	logs, err := NewCommand("log", prInfo.MergeBase+"..."+headBranch, _PRETTY_LOG_FORMAT).RunInDirBytes(repo.Path)
+	logs, err := NewCommand("log", prInfo.MergeBase+"..."+headBranch, prettyLogFormat).RunInDirBytes(repo.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -29,7 +29,7 @@ func (repo *Repository) CreateTag(name, revision string) error {
 	return err
 }
 
-func (repo *Repository) getTag(id sha1) (*Tag, error) {
+func (repo *Repository) getTag(id SHA1) (*Tag, error) {
 	t, ok := repo.tagCache.Get(id.String())
 	if ok {
 		log("Hit cache: %s", id)

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -10,17 +10,20 @@ import (
 	"github.com/mcuadros/go-version"
 )
 
-const TAG_PREFIX = "refs/tags/"
+// TagPrefix tags prefix path on the repository
+const TagPrefix = "refs/tags/"
 
 // IsTagExist returns true if given tag exists in the repository.
 func IsTagExist(repoPath, name string) bool {
-	return IsReferenceExist(repoPath, TAG_PREFIX+name)
+	return IsReferenceExist(repoPath, TagPrefix+name)
 }
 
+// IsTagExist returns true if given tag exists in the repository.
 func (repo *Repository) IsTagExist(name string) bool {
 	return IsTagExist(repo.Path, name)
 }
 
+// CreateTag create one tag in the repository
 func (repo *Repository) CreateTag(name, revision string) error {
 	_, err := NewCommand("tag", name, revision).RunInDir(repo.Path)
 	return err
@@ -41,11 +44,11 @@ func (repo *Repository) getTag(id sha1) (*Tag, error) {
 	tp = strings.TrimSpace(tp)
 
 	// Tag is a commit.
-	if ObjectType(tp) == OBJECT_COMMIT {
+	if ObjectType(tp) == ObjectCommit {
 		tag := &Tag{
 			ID:     id,
 			Object: id,
-			Type:   string(OBJECT_COMMIT),
+			Type:   string(ObjectCommit),
 			repo:   repo,
 		}
 
@@ -110,7 +113,7 @@ func (repo *Repository) GetTags() ([]string, error) {
 		version.Sort(tags)
 
 		// Reverse order
-		for i := 0; i < len(tags) / 2; i++ {
+		for i := 0; i < len(tags)/2; i++ {
 			j := len(tags) - i - 1
 			tags[i], tags[j] = tags[j], tags[i]
 		}

--- a/repo_tree.go
+++ b/repo_tree.go
@@ -4,7 +4,7 @@
 
 package git
 
-func (repo *Repository) getTree(id sha1) (*Tree, error) {
+func (repo *Repository) getTree(id SHA1) (*Tree, error) {
 	treePath := filepathFromSHA1(repo.Path, id.String())
 	if isFile(treePath) {
 		_, err := NewCommand("ls-tree", id.String()).RunInDir(repo.Path)

--- a/repo_tree.go
+++ b/repo_tree.go
@@ -16,7 +16,7 @@ func (repo *Repository) getTree(id sha1) (*Tree, error) {
 	return NewTree(repo, id), nil
 }
 
-// Find the tree object in the repository.
+// GetTree find the tree object in the repository.
 func (repo *Repository) GetTree(idStr string) (*Tree, error) {
 	id, err := NewIDFromString(idStr)
 	if err != nil {

--- a/sha1.go
+++ b/sha1.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-const EMPTY_SHA = "0000000000000000000000000000000000000000"
+const emptySHA = "0000000000000000000000000000000000000000"
 
 type sha1 [20]byte
 
@@ -45,12 +45,12 @@ func (id sha1) Equal(s2 interface{}) bool {
 }
 
 // String returns string (hex) representation of the Oid.
-func (s sha1) String() string {
+func (id sha1) String() string {
 	result := make([]byte, 0, 40)
 	hexvalues := []byte("0123456789abcdef")
 	for i := 0; i < 20; i++ {
-		result = append(result, hexvalues[s[i]>>4])
-		result = append(result, hexvalues[s[i]&0xf])
+		result = append(result, hexvalues[id[i]>>4])
+		result = append(result, hexvalues[id[i]&0xf])
 	}
 	return string(result)
 }

--- a/sha1.go
+++ b/sha1.go
@@ -12,11 +12,12 @@ import (
 
 const emptySHA = "0000000000000000000000000000000000000000"
 
-type sha1 [20]byte
+// SHA1 a git commit name
+type SHA1 [20]byte
 
-// Equal returns true if s has the same sha1 as caller.
-// Support 40-length-string, []byte, sha1.
-func (id sha1) Equal(s2 interface{}) bool {
+// Equal returns true if s has the same SHA1 as caller.
+// Support 40-length-string, []byte, SHA1.
+func (id SHA1) Equal(s2 interface{}) bool {
 	switch v := s2.(type) {
 	case string:
 		if len(v) != 40 {
@@ -32,7 +33,7 @@ func (id sha1) Equal(s2 interface{}) bool {
 				return false
 			}
 		}
-	case sha1:
+	case SHA1:
 		for i, v := range v {
 			if id[i] != v {
 				return false
@@ -45,7 +46,7 @@ func (id sha1) Equal(s2 interface{}) bool {
 }
 
 // String returns string (hex) representation of the Oid.
-func (id sha1) String() string {
+func (id SHA1) String() string {
 	result := make([]byte, 0, 40)
 	hexvalues := []byte("0123456789abcdef")
 	for i := 0; i < 20; i++ {
@@ -55,32 +56,32 @@ func (id sha1) String() string {
 	return string(result)
 }
 
-// MustID always creates a new sha1 from a [20]byte array with no validation of input.
-func MustID(b []byte) sha1 {
-	var id sha1
+// MustID always creates a new SHA1 from a [20]byte array with no validation of input.
+func MustID(b []byte) SHA1 {
+	var id SHA1
 	for i := 0; i < 20; i++ {
 		id[i] = b[i]
 	}
 	return id
 }
 
-// NewID creates a new sha1 from a [20]byte array.
-func NewID(b []byte) (sha1, error) {
+// NewID creates a new SHA1 from a [20]byte array.
+func NewID(b []byte) (SHA1, error) {
 	if len(b) != 20 {
-		return sha1{}, fmt.Errorf("Length must be 20: %v", b)
+		return SHA1{}, fmt.Errorf("Length must be 20: %v", b)
 	}
 	return MustID(b), nil
 }
 
 // MustIDFromString always creates a new sha from a ID with no validation of input.
-func MustIDFromString(s string) sha1 {
+func MustIDFromString(s string) SHA1 {
 	b, _ := hex.DecodeString(s)
 	return MustID(b)
 }
 
-// NewIDFromString creates a new sha1 from a ID string of length 40.
-func NewIDFromString(s string) (sha1, error) {
-	var id sha1
+// NewIDFromString creates a new SHA1 from a ID string of length 40.
+func NewIDFromString(s string) (SHA1, error) {
+	var id SHA1
 	s = strings.TrimSpace(s)
 	if len(s) != 40 {
 		return id, fmt.Errorf("Length must be 40: %s", s)

--- a/submodule.go
+++ b/submodule.go
@@ -6,6 +6,7 @@ package git
 
 import "strings"
 
+// SubModule submodule is a reference on git repository
 type SubModule struct {
 	Name string
 	URL  string
@@ -19,6 +20,7 @@ type SubModuleFile struct {
 	refID  string
 }
 
+// NewSubModuleFile create a new submodule file
 func NewSubModuleFile(c *Commit, refURL, refID string) *SubModuleFile {
 	return &SubModuleFile{
 		Commit: c,
@@ -64,9 +66,8 @@ func (sf *SubModuleFile) RefURL(urlPrefix string, parentPath string) string {
 		// fix problem with reverse proxy works only with local server
 		if strings.Contains(urlPrefix, url[i+1:j]) {
 			return urlPrefix + url[j+1:]
-		} else {
-			return "http://" + url[i+1:j] + "/" + url[j+1:]
 		}
+		return "http://" + url[i+1:j] + "/" + url[j+1:]
 	}
 
 	return url

--- a/tag.go
+++ b/tag.go
@@ -9,9 +9,9 @@ import "bytes"
 // Tag represents a Git tag.
 type Tag struct {
 	Name    string
-	ID      sha1
+	ID      SHA1
 	repo    *Repository
-	Object  sha1 // The id of this commit object
+	Object  SHA1 // The id of this commit object
 	Type    string
 	Tagger  *Signature
 	Message string

--- a/tag.go
+++ b/tag.go
@@ -17,6 +17,7 @@ type Tag struct {
 	Message string
 }
 
+// Commit return the commit of the tag reference
 func (tag *Tag) Commit() (*Commit, error) {
 	return tag.repo.getCommit(tag.Object)
 }

--- a/tree.go
+++ b/tree.go
@@ -12,7 +12,7 @@ import (
 
 // Tree represents a flat directory listing.
 type Tree struct {
-	ID   sha1
+	ID   SHA1
 	repo *Repository
 
 	// parent tree
@@ -23,7 +23,7 @@ type Tree struct {
 }
 
 // NewTree create a new tree according the repository and commit id
-func NewTree(repo *Repository, id sha1) *Tree {
+func NewTree(repo *Repository, id SHA1) *Tree {
 	return &Tree{
 		ID:   id,
 		repo: repo,
@@ -91,7 +91,7 @@ func parseTreeData(tree *Tree, data []byte) ([]*TreeEntry, error) {
 			return nil, err
 		}
 		entry.ID = id
-		pos += step + 1 // Skip half of sha1.
+		pos += step + 1 // Skip half of SHA1.
 
 		step = bytes.IndexByte(data[pos:], '\n')
 

--- a/tree.go
+++ b/tree.go
@@ -22,6 +22,7 @@ type Tree struct {
 	entriesParsed bool
 }
 
+// NewTree create a new tree according the repository and commit id
 func NewTree(repo *Repository, id sha1) *Tree {
 	return &Tree{
 		ID:   id,
@@ -63,22 +64,22 @@ func parseTreeData(tree *Tree, data []byte) ([]*TreeEntry, error) {
 		step := 6
 		switch string(data[pos : pos+step]) {
 		case "100644":
-			entry.mode = ENTRY_MODE_BLOB
-			entry.Type = OBJECT_BLOB
+			entry.mode = EntryModeBlob
+			entry.Type = ObjectBlob
 		case "100755":
-			entry.mode = ENTRY_MODE_EXEC
-			entry.Type = OBJECT_BLOB
+			entry.mode = EntryModeExec
+			entry.Type = ObjectBlob
 		case "120000":
-			entry.mode = ENTRY_MODE_SYMLINK
-			entry.Type = OBJECT_BLOB
+			entry.mode = EntryModeSymlink
+			entry.Type = ObjectBlob
 		case "160000":
-			entry.mode = ENTRY_MODE_COMMIT
-			entry.Type = OBJECT_COMMIT
+			entry.mode = EntryModeCommit
+			entry.Type = ObjectCommit
 
 			step = 8
 		case "040000":
-			entry.mode = ENTRY_MODE_TREE
-			entry.Type = OBJECT_TREE
+			entry.mode = EntryModeTree
+			entry.Type = ObjectTree
 		default:
 			return nil, fmt.Errorf("unknown type: %v", string(data[pos:pos+step]))
 		}
@@ -107,6 +108,7 @@ func parseTreeData(tree *Tree, data []byte) ([]*TreeEntry, error) {
 	return entries, nil
 }
 
+// SubTree get a sub tree by the sub dir path
 func (t *Tree) SubTree(rpath string) (*Tree, error) {
 	if len(rpath) == 0 {
 		return t, nil

--- a/tree_blob.go
+++ b/tree_blob.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 )
 
+// GetTreeEntryByPath get the tree entries accroding the sub dir
 func (t *Tree) GetTreeEntryByPath(relpath string) (*TreeEntry, error) {
 	if len(relpath) == 0 {
 		return &TreeEntry{
 			ID:   t.ID,
-			Type: OBJECT_TREE,
-			mode: ENTRY_MODE_TREE,
+			Type: ObjectTree,
+			mode: EntryModeTree,
 		}, nil
 	}
 
@@ -43,6 +44,7 @@ func (t *Tree) GetTreeEntryByPath(relpath string) (*TreeEntry, error) {
 	return nil, ErrNotExist{"", relpath}
 }
 
+// GetBlobByPath get the blob object accroding the path
 func (t *Tree) GetBlobByPath(relpath string) (*Blob, error) {
 	entry, err := t.GetTreeEntryByPath(relpath)
 	if err != nil {

--- a/tree_entry.go
+++ b/tree_entry.go
@@ -14,18 +14,25 @@ import (
 	"strings"
 )
 
+// EntryMode the type of the object in the git tree
 type EntryMode int
 
 // There are only a few file modes in Git. They look like unix file modes, but they can only be
 // one of these.
 const (
-	ENTRY_MODE_BLOB    EntryMode = 0100644
-	ENTRY_MODE_EXEC    EntryMode = 0100755
-	ENTRY_MODE_SYMLINK EntryMode = 0120000
-	ENTRY_MODE_COMMIT  EntryMode = 0160000
-	ENTRY_MODE_TREE    EntryMode = 0040000
+	// EntryModeBlob
+	EntryModeBlob EntryMode = 0100644
+	// EntryModeExec
+	EntryModeExec EntryMode = 0100755
+	// EntryModeSymlink
+	EntryModeSymlink EntryMode = 0120000
+	// EntryModeCommit
+	EntryModeCommit EntryMode = 0160000
+	// EntryModeTree
+	EntryModeTree EntryMode = 0040000
 )
 
+// TreeEntry the leaf in the git tree
 type TreeEntry struct {
 	ID   sha1
 	Type ObjectType
@@ -41,10 +48,12 @@ type TreeEntry struct {
 	sized bool
 }
 
+// Name returns the name of the entry
 func (te *TreeEntry) Name() string {
 	return te.name
 }
 
+// Size returns the size of the entry
 func (te *TreeEntry) Size() int64 {
 	if te.IsDir() {
 		return 0
@@ -62,14 +71,17 @@ func (te *TreeEntry) Size() int64 {
 	return te.size
 }
 
+// IsSubModule if the entry is a sub module
 func (te *TreeEntry) IsSubModule() bool {
-	return te.mode == ENTRY_MODE_COMMIT
+	return te.mode == EntryModeCommit
 }
 
+// IsDir if the entry is a sub dir
 func (te *TreeEntry) IsDir() bool {
-	return te.mode == ENTRY_MODE_TREE
+	return te.mode == EntryModeTree
 }
 
+// Blob retrun the blob object the entry
 func (te *TreeEntry) Blob() *Blob {
 	return &Blob{
 		repo:      te.ptree.repo,
@@ -77,6 +89,7 @@ func (te *TreeEntry) Blob() *Blob {
 	}
 }
 
+// Entries a list of entry
 type Entries []*TreeEntry
 
 var sorter = []func(t1, t2 *TreeEntry) bool{
@@ -105,6 +118,7 @@ func (tes Entries) Less(i, j int) bool {
 	return sorter[k](t1, t2)
 }
 
+// Sort sort the list of entry
 func (tes Entries) Sort() {
 	sort.Sort(tes)
 }
@@ -167,7 +181,7 @@ func (tes Entries) GetCommitsInfoWithCustomConcurrency(commit *Commit, treePath 
 		// However when taskChan is full, code will block and wait any running goroutines to finish.
 		taskChan <- true
 
-		if tes[i].Type != OBJECT_COMMIT {
+		if tes[i].Type != ObjectCommit {
 			go func(i int) {
 				cinfo := commitInfo{entryName: tes[i].Name()}
 				c, err := commit.GetCommitByPath(filepath.Join(treePath, tes[i].Name()))

--- a/tree_entry.go
+++ b/tree_entry.go
@@ -34,7 +34,7 @@ const (
 
 // TreeEntry the leaf in the git tree
 type TreeEntry struct {
-	ID   sha1
+	ID   SHA1
 	Type ObjectType
 
 	mode EntryMode

--- a/utlis.go
+++ b/utlis.go
@@ -12,26 +12,28 @@ import (
 	"sync"
 )
 
-// objectCache provides thread-safe cache opeations.
-type objectCache struct {
+// ObjectCache provides thread-safe cache opeations.
+type ObjectCache struct {
 	lock  sync.RWMutex
 	cache map[string]interface{}
 }
 
-func newObjectCache() *objectCache {
-	return &objectCache{
+func newObjectCache() *ObjectCache {
+	return &ObjectCache{
 		cache: make(map[string]interface{}, 10),
 	}
 }
 
-func (oc *objectCache) Set(id string, obj interface{}) {
+// Set add obj to cache
+func (oc *ObjectCache) Set(id string, obj interface{}) {
 	oc.lock.Lock()
 	defer oc.lock.Unlock()
 
 	oc.cache[id] = obj
 }
 
-func (oc *objectCache) Get(id string) (interface{}, bool) {
+// Get get cached obj by id
+func (oc *ObjectCache) Get(id string) (interface{}, bool) {
 	oc.lock.RLock()
 	defer oc.lock.RUnlock()
 

--- a/utlis.go
+++ b/utlis.go
@@ -80,13 +80,14 @@ func filepathFromSHA1(rootdir, sha1 string) string {
 	return filepath.Join(rootdir, "objects", sha1[:2], sha1[2:])
 }
 
+// RefEndName return the end name of a ref name
 func RefEndName(refStr string) string {
-	if strings.HasPrefix(refStr, BRANCH_PREFIX) {
-		return refStr[len(BRANCH_PREFIX):]
+	if strings.HasPrefix(refStr, BranchPrefix) {
+		return refStr[len(BranchPrefix):]
 	}
 
-	if strings.HasPrefix(refStr, TAG_PREFIX) {
-		return refStr[len(TAG_PREFIX):]
+	if strings.HasPrefix(refStr, TagPrefix) {
+		return refStr[len(TagPrefix):]
 	}
 
 	return refStr


### PR DESCRIPTION
This PR will fix the golint errors. But we need set the golint minimal confidence to 0.9 although the default confidence is 0.8, because there are some errors could not be resolved currently. If you have any idea, please send a new PR to fix it.

```
commit.go:42:35: exported method ParentID returns unexported type git.sha1, which can be annoying to use
commit.go:211:35: exported method GetSubModules returns unexported type *git.objectCache, which can be annoying to use
sha1.go:59:23: exported func MustID returns unexported type git.sha1, which can be annoying to use
sha1.go:68:23: exported func NewID returns unexported type git.sha1, which can be annoying to use
sha1.go:76:33: exported func MustIDFromString returns unexported type git.sha1, which can be annoying to use
sha1.go:82:33: exported func NewIDFromString returns unexported type git.sha1, which can be annoying to use
```