### PR TITLE
Adding git blame

### DIFF
--- a/repo_blame.go
+++ b/repo_blame.go
@@ -1,0 +1,10 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+// FileBlame return the Blame object of file
+func (repo *Repository) FileBlame(revision, path, file string) ([]byte, error) {
+	return NewCommand("blame", "--root", file).RunInDirBytes(path)
+}


### PR DESCRIPTION
Adding git-blame implementation. Prepare for git blame [feature](https://github.com/go-gitea/gitea/issues/747) implementation.