### PR TITLE
Add GPG payload to commit information if present

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -6,6 +6,7 @@ package git
 
 import (
 	"bufio"
+	"bytes"
 	"container/list"
 	"fmt"
 	"net/http"
@@ -22,9 +23,29 @@ type Commit struct {
 	Author        *Signature
 	Committer     *Signature
 	CommitMessage string
+	Signature     *CommitGPGSignature
 
 	parents        []SHA1 // SHA1 strings
 	submoduleCache *ObjectCache
+}
+
+// CommitGPGSignature represents a git commit signature part.
+type CommitGPGSignature struct {
+	Signature string
+	Payload   string //TODO check if can be reconstruct from the rest of commit information to not have duplicate data
+}
+
+// similar to https://github.com/git/git/blob/3bc53220cb2dcf709f7a027a3f526befd021d858/commit.c#L1128
+func newGPGSignatureFromCommitline(data []byte, signatureStart int) (*CommitGPGSignature, error) {
+	sig := new(CommitGPGSignature)
+	sig.Payload = string(data[:signatureStart-8])
+	signatureEnd := bytes.LastIndex(data, []byte("-----END PGP SIGNATURE-----"))
+	if signatureEnd == -1 {
+		return nil, fmt.Errorf("end of commit signature not found")
+	}
+	sig.Signature = string(data[signatureStart : signatureEnd+27])
+
+	return sig, nil
 }
 
 // Message returns the commit message. Same as retrieving CommitMessage directly.

--- a/commit.go
+++ b/commit.go
@@ -38,13 +38,12 @@ type CommitGPGSignature struct {
 // similar to https://github.com/git/git/blob/3bc53220cb2dcf709f7a027a3f526befd021d858/commit.c#L1128
 func newGPGSignatureFromCommitline(data []byte, signatureStart int) (*CommitGPGSignature, error) {
 	sig := new(CommitGPGSignature)
-	sig.Payload = string(data[:signatureStart-8])
 	signatureEnd := bytes.LastIndex(data, []byte("-----END PGP SIGNATURE-----"))
 	if signatureEnd == -1 {
 		return nil, fmt.Errorf("end of commit signature not found")
 	}
-	sig.Signature = string(data[signatureStart : signatureEnd+27])
-
+	sig.Signature = strings.Replace(string(data[signatureStart:signatureEnd+27]), "\n ", "\n", -1)
+	sig.Payload = string(data[:signatureStart-8]) + string(data[signatureEnd+27:])
 	return sig, nil
 }
 

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -78,6 +78,12 @@ l:
 					return nil, err
 				}
 				commit.Committer = sig
+			case "gpgsig":
+				sig, err := newGPGSignatureFromCommitline(data, nextline+spacepos+1)
+				if err != nil {
+					return nil, err
+				}
+				commit.Signature = sig
 			}
 			nextline += eol + 1
 		case eol == 0:


### PR DESCRIPTION
based on : https://github.com/git/git/blob/3bc53220cb2dcf709f7a027a3f526befd021d858/commit.c#L1128
I have to do further testing to determine if the struct CommitGPGSignature could not be replace by a simple string representing directly CommitGPGSignature.Signature. Since payload can maybe re-created from the rest of data in Commit struct.

If we don't care about duplicate of data at this stage it will simplify treatment after since payload and signature (+ public key from keystore in gitea) is only needed to verify the signed commit. https://github.com/git/git/blob/2cc2e70264e0fcba04f9ef791d144bbc8b501206/gpg-interface.c#L204
