### PR TITLE
Return empty list of branches if repository is bare.

### DIFF
--- a/repo_branch.go
+++ b/repo_branch.go
@@ -66,19 +66,15 @@ func (repo *Repository) SetDefaultBranch(name string) error {
 
 // GetBranches returns all branches of the repository.
 func (repo *Repository) GetBranches() ([]string, error) {
-	stdout, err := NewCommand("show-ref", "--heads").RunInDir(repo.Path)
+	stdout, err := NewCommand("for-each-ref", "--format=%(refname)", BranchPrefix).RunInDir(repo.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	infos := strings.Split(stdout, "\n")
-	branches := make([]string, len(infos)-1)
-	for i, info := range infos[:len(infos)-1] {
-		fields := strings.Fields(info)
-		if len(fields) != 2 {
-			continue // NOTE: I should believe git will not give me wrong string.
-		}
-		branches[i] = strings.TrimPrefix(fields[1], BranchPrefix)
+	refs := strings.Split(stdout, "\n")
+	branches := make([]string, len(refs)-1)
+	for i, ref := range refs[:len(refs)-1] {
+		branches[i] = strings.TrimPrefix(ref, BranchPrefix)
 	}
 	return branches, nil
 }


### PR DESCRIPTION
This pull request enables the git module to handle bare (empty) repositories when getting all branches of a repository. This failed previously, because the command to retrieve the branches `git show-ref --heads` exited with return code `1` which resulted in a non-nil error.

The new implementation uses `git for-each-ref` to iterate over all branches and outputs nothing in case the repository is bare while using a return code of `0`. As the output format changed (and now is much simpler), the parsing of that output had to be changed as well.

This is in preparation of a coming pull request to gitea itself to [gracefully handle bare repositories on various API operations](https://github.com/cybe/gitea/commit/9f0e75a70b4415bd5be0a49586996d34961dfa7d) instead of throwing HTTP-500 errors.