### PR TITLE
Panic if Git version is < GitVersionRequired

### DIFF
--- a/git.go
+++ b/git.go
@@ -1,5 +1,5 @@
 // Copyright 2015 The Gogs Authors. All rights reserved.
-// Copyright 2017 The Gogs Authors. All rights reserved.
+// Copyright 2017 The Gitea Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 

--- a/git.go
+++ b/git.go
@@ -1,4 +1,5 @@
 // Copyright 2015 The Gogs Authors. All rights reserved.
+// Copyright 2017 The Gogs Authors. All rights reserved.
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
@@ -8,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/mcuadros/go-version"
 )
 
 // Version return this package's current version
@@ -21,6 +24,8 @@ var (
 	Debug = false
 	// Prefix the log prefix
 	Prefix = "[git-module] "
+	// Minimum Git version required
+	GitVersionRequired = "1.7.10"
 )
 
 func log(format string, args ...interface{}) {
@@ -66,7 +71,13 @@ func BinVersion() (string, error) {
 }
 
 func init() {
-	BinVersion()
+	gitVersion, err := BinVersion()
+	if err != nil {
+		panic(fmt.Sprintf("Git version missing: %v", err))
+	}
+	if version.Compare(gitVersion, GitVersionRequired, "<") {
+		panic(fmt.Sprintf("Git version not supported. Requires version > %v", GitVersionRequired))
+	}
 }
 
 // Fsck verifies the connectivity and validity of the objects in the database

--- a/git.go
+++ b/git.go
@@ -24,7 +24,7 @@ var (
 	Debug = false
 	// Prefix the log prefix
 	Prefix = "[git-module] "
-	// Minimum Git version required
+	// GitVersionRequired is the minimum Git version required
 	GitVersionRequired = "1.7.10"
 )
 


### PR DESCRIPTION
Panic during init() if Git version is < GitVersionRequired.
I have set the min version to 1.7.10 as required by SetDefaultBranch (https://github.com/go-gitea/git/blob/master/repo_branch.go#L58). I'm not sure why 1.7.10 is required for SetDefaultBranch, symbolic-ref has been in there for a while https://git-scm.com/docs/git-symbolic-ref/1.4.4.

Ref: https://github.com/go-gitea/gitea/issues/1133