### PR TITLE
Optimization for blob.Data method

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -16,16 +16,29 @@ type Blob struct {
 }
 
 // Data gets content of blob all at once and wrap it as io.Reader.
-// This can be very slow and memory consuming for huge content.
-func (b *Blob) Data() (io.Reader, error) {
-	stdout, err := NewCommand("show", b.ID.String()).RunInDirBytes(b.repo.Path)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewBuffer(stdout), nil
+// WARNING: the io.PipeReader should be read or close on the invoke place
+func (b *Blob) Data() (*io.PipeReader, error) {
+	r, w := io.Pipe()
+
+	var err error
+	go func() {
+		defer w.Close()
+
+		stderr := new(bytes.Buffer)
+		err = b.DataPipeline(w, stderr)
+		err = concatenateError(err, stderr.String())
+	}()
+
+	return r, err
 }
 
 // DataPipeline gets content of blob and write the result or error to stdout or stderr
 func (b *Blob) DataPipeline(stdout, stderr io.Writer) error {
 	return NewCommand("show", b.ID.String()).RunInDirPipeline(b.repo.Path, stdout, stderr)
+}
+
+// Bytes gets content of blob all at once.
+// This can be very slow and memory consuming for huge content but for small object it's enough
+func (b *Blob) Bytes() ([]byte, error) {
+	return NewCommand("show", b.ID.String()).RunInDirBytes(b.repo.Path)
 }


### PR DESCRIPTION
Old Data method will read all blob to the memory and then wrap it as a `io.Reader`, this is unnecessary.