### PR TITLE
Faster commit lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 coverage.out
+
+benchmark_repos/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ _testmain.go
 
 coverage.out
 
-benchmark_repos/
+benchmark/

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ lint:
 test:
 	for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
 
+.PHONY: bench
+bench:
+	go test -run=XXX -bench=. || exit 1
+
 .PHONY: build
 build:
 	go build .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMPORT := code.gitea.io/git
 
-PACKAGES ?= $(shell go list -e ./... | grep -v /vendor/ | grep -v /benchmark_repos/)
+PACKAGES ?= $(shell go list -e ./... | grep -v /vendor/ | grep -v /benchmark/)
 GENERATE ?= code.gitea.io/git
 
 .PHONY: all
@@ -18,7 +18,7 @@ generate:
 
 .PHONY: fmt
 fmt:
-	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark_repos/*" | xargs gofmt -s -w
+	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMPORT := code.gitea.io/git
 
-PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+PACKAGES ?= $(shell go list -e ./... | grep -v /vendor/ | grep -v /benchmark_repos/)
 GENERATE ?= code.gitea.io/git
 
 .PHONY: all
@@ -18,7 +18,7 @@ generate:
 
 .PHONY: fmt
 fmt:
-	find . -name "*.go" -type f -not -path "./vendor/*" | xargs gofmt -s -w
+	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark_repos/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test:
 
 .PHONY: bench
 bench:
-	go test -run=XXX -bench=. || exit 1
+	go test -run=XXXXXX -benchtime=10s -bench=. || exit 1
 
 .PHONY: build
 build:

--- a/tree_entry.go
+++ b/tree_entry.go
@@ -5,10 +5,7 @@
 package git
 
 import (
-	"fmt"
-	"path"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -147,112 +144,147 @@ func (tes Entries) Sort() {
 	sort.Sort(tes)
 }
 
-type commitInfo struct {
-	entryName string
-	infos     []interface{}
-	err       error
+// getCommitInfoState transient state for getting commit info for entries
+type getCommitInfoState struct {
+	entries        map[string]*TreeEntry // map from filepath to entry
+	commits        map[string]*Commit    // map from entry name to commit
+	lastCommitHash string
+	lastCommit     *Commit
+	treePath       string
+	headCommit     *Commit
+	nextSearchSize int // next number of commits to search for
 }
 
-// GetCommitsInfo takes advantages of concurrency to speed up getting information
-// of all commits that are corresponding to these entries. This method will automatically
-// choose the right number of goroutine (concurrency) to use related of the host CPU.
+func initGetCommitInfoState(entries Entries, headCommit *Commit, treePath string) *getCommitInfoState {
+	entriesByPath := make(map[string]*TreeEntry, len(entries))
+	for _, entry := range entries {
+		entriesByPath[filepath.Join(treePath, entry.Name())] = entry
+	}
+	return &getCommitInfoState{
+		entries:        entriesByPath,
+		commits:        make(map[string]*Commit, len(entriesByPath)),
+		treePath:       treePath,
+		headCommit:     headCommit,
+		nextSearchSize: 16,
+	}
+}
+
+// GetCommitsInfo gets information of all commits that are corresponding to these entries
 func (tes Entries) GetCommitsInfo(commit *Commit, treePath string) ([][]interface{}, error) {
-	return tes.GetCommitsInfoWithCustomConcurrency(commit, treePath, 0)
-}
-
-// GetCommitsInfoWithCustomConcurrency takes advantages of concurrency to speed up getting information
-// of all commits that are corresponding to these entries. If the given maxConcurrency is negative or
-// equal to zero:  the right number of goroutine (concurrency) to use will be chosen related of the
-// host CPU.
-func (tes Entries) GetCommitsInfoWithCustomConcurrency(commit *Commit, treePath string, maxConcurrency int) ([][]interface{}, error) {
-	if len(tes) == 0 {
-		return nil, nil
-	}
-
-	if maxConcurrency <= 0 {
-		maxConcurrency = runtime.NumCPU()
-	}
-
-	// Length of taskChan determines how many goroutines (subprocesses) can run at the same time.
-	// The length of revChan should be same as taskChan so goroutines whoever finished job can
-	// exit as early as possible, only store data inside channel.
-	taskChan := make(chan bool, maxConcurrency)
-	revChan := make(chan commitInfo, maxConcurrency)
-	doneChan := make(chan error)
-
-	// Receive loop will exit when it collects same number of data pieces as tree entries.
-	// It notifies doneChan before exits or notify early with possible error.
-	infoMap := make(map[string][]interface{}, len(tes))
-	go func() {
-		i := 0
-		for info := range revChan {
-			if info.err != nil {
-				doneChan <- info.err
-				return
-			}
-
-			infoMap[info.entryName] = info.infos
-			i++
-			if i == len(tes) {
-				break
-			}
-		}
-		doneChan <- nil
-	}()
-
-	for i := range tes {
-		// When taskChan is idle (or has empty slots), put operation will not block.
-		// However when taskChan is full, code will block and wait any running goroutines to finish.
-		taskChan <- true
-
-		if tes[i].Type != ObjectCommit {
-			go func(i int) {
-				cinfo := commitInfo{entryName: tes[i].Name()}
-				c, err := commit.GetCommitByPath(filepath.Join(treePath, tes[i].Name()))
-				if err != nil {
-					cinfo.err = fmt.Errorf("GetCommitByPath (%s/%s): %v", treePath, tes[i].Name(), err)
-				} else {
-					cinfo.infos = []interface{}{tes[i], c}
-				}
-				revChan <- cinfo
-				<-taskChan // Clear one slot from taskChan to allow new goroutines to start.
-			}(i)
-			continue
-		}
-
-		// Handle submodule
-		go func(i int) {
-			cinfo := commitInfo{entryName: tes[i].Name()}
-			sm, err := commit.GetSubModule(path.Join(treePath, tes[i].Name()))
-			if err != nil && !IsErrNotExist(err) {
-				cinfo.err = fmt.Errorf("GetSubModule (%s/%s): %v", treePath, tes[i].Name(), err)
-				revChan <- cinfo
-				return
-			}
-
-			smURL := ""
-			if sm != nil {
-				smURL = sm.URL
-			}
-
-			c, err := commit.GetCommitByPath(filepath.Join(treePath, tes[i].Name()))
-			if err != nil {
-				cinfo.err = fmt.Errorf("GetCommitByPath (%s/%s): %v", treePath, tes[i].Name(), err)
-			} else {
-				cinfo.infos = []interface{}{tes[i], NewSubModuleFile(c, smURL, tes[i].ID.String())}
-			}
-			revChan <- cinfo
-			<-taskChan
-		}(i)
-	}
-
-	if err := <-doneChan; err != nil {
+	state := initGetCommitInfoState(tes, commit, treePath)
+	if err := getCommitsInfo(state); err != nil {
 		return nil, err
 	}
 
 	commitsInfo := make([][]interface{}, len(tes))
-	for i := 0; i < len(tes); i++ {
-		commitsInfo[i] = infoMap[tes[i].Name()]
+	for i, entry := range tes {
+		commit = state.commits[filepath.Join(treePath, entry.Name())]
+		switch entry.Type {
+		case ObjectCommit:
+			subModuleURL := ""
+			if subModule, err := state.headCommit.GetSubModule(entry.Name()); err != nil {
+				return nil, err
+			} else if subModule != nil {
+				subModuleURL = subModule.URL
+			}
+			subModuleFile := NewSubModuleFile(commit, subModuleURL, entry.ID.String())
+			commitsInfo[i] = []interface{}{entry, subModuleFile}
+		default:
+			commitsInfo[i] = []interface{}{entry, commit}
+		}
 	}
 	return commitsInfo, nil
+}
+
+func (state *getCommitInfoState) nextCommit(hash string) {
+	state.lastCommitHash = hash
+	state.lastCommit = nil
+}
+
+func (state *getCommitInfoState) commit() (*Commit, error) {
+	var err error
+	if state.lastCommit == nil {
+		state.lastCommit, err = state.headCommit.repo.GetCommit(state.lastCommitHash)
+	}
+	return state.lastCommit, err
+}
+
+func (state *getCommitInfoState) update(path string) error {
+	relPath, err := filepath.Rel(state.treePath, path)
+	if err != nil {
+		return nil
+	}
+	var entryPath string
+	if index := strings.IndexRune(relPath, '/'); index >= 0 {
+		entryPath = filepath.Join(state.treePath, relPath[:index])
+	} else {
+		entryPath = path
+	}
+	if _, ok := state.entries[entryPath]; !ok {
+		return nil
+	} else if _, ok := state.commits[entryPath]; ok {
+		return nil
+	}
+	state.commits[entryPath], err = state.commit()
+	return err
+}
+
+func getCommitsInfo(state *getCommitInfoState) error {
+	for len(state.entries) > len(state.commits) {
+		if err := getNextCommitInfos(state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getNextCommitInfos(state *getCommitInfoState) error {
+	logOutput, err := logCommand(state.lastCommitHash, state).RunInDir(state.headCommit.repo.Path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(logOutput, "\n")
+	i := 0
+	for i < len(lines) {
+		state.nextCommit(lines[i])
+		i++
+		for ; i < len(lines); i++ {
+			path := lines[i]
+			if path == "" {
+				break
+			}
+			state.update(path)
+		}
+		i++ // skip blank line
+		if len(state.entries) == len(state.commits) {
+			break
+		}
+	}
+	return nil
+}
+
+func logCommand(exclusiveStartHash string, state *getCommitInfoState) *Command {
+	var commitHash string
+	if len(exclusiveStartHash) == 0 {
+		commitHash = "HEAD"
+	} else {
+		commitHash = exclusiveStartHash + "^"
+	}
+	var command *Command
+	numRemainingEntries := len(state.entries) - len(state.commits)
+	if numRemainingEntries < 32 {
+		searchSize := (numRemainingEntries + 1) / 2
+		command = NewCommand("log", prettyLogFormat, "--name-only",
+			"-"+strconv.Itoa(searchSize), commitHash, "--")
+		for path, entry := range state.entries {
+			if _, ok := state.commits[entry.Name()]; !ok {
+				command.AddArguments(path)
+			}
+		}
+	} else {
+		command = NewCommand("log", prettyLogFormat, "--name-only",
+			"-"+strconv.Itoa(state.nextSearchSize), commitHash, "--", state.treePath)
+	}
+	state.nextSearchSize += state.nextSearchSize
+	return command
 }

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func setupGitRepo(url string) string {
+	
+	dir, err := ioutil.TempDir("", "gitea-bench")
+	if err != nil {
+		panic(err)
+	}
+	/* Manual method
+	_, err = NewCommand("clone", url, dir).Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+	*/
+	err = Clone(url, dir, CloneRepoOptions{Mirror: false, Bare: false, Quiet: true})
+	if err != nil {
+		panic(err)
+	}
+	return dir
+}
+
+func benchmarkGetCommitsInfo(url string, b *testing.B) {
+
+	// setup env
+	repoPath := setupGitRepo(url)
+	defer os.RemoveAll(repoPath)
+
+	repo, err := OpenRepository(repoPath)
+	if err != nil {
+		panic(err)
+	}
+
+	commit, err := repo.GetBranchCommit("master")
+	if err != nil {
+		panic(err)
+	}
+
+	entries, err := commit.Tree.ListEntries()
+	if err != nil {
+		panic(err)
+	}
+	entries.Sort()
+
+	// run the GetCommitsInfo function b.N times
+	for n := 0; n < b.N; n++ {
+		_, err = entries.GetCommitsInfo(commit, "")
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+
+func BenchmarkGetCommitsInfoGitea(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/go-gitea/gitea.git", b) } //5k+ commits
+func BenchmarkGetCommitsInfoMoby(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/moby/moby.git", b) } //32k+ commits
+func BenchmarkGetCommitsInfoGo(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/golang/go.git", b) } //+32k commits

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -28,6 +28,7 @@ func setupGitRepo(url string) string {
 	return dir
 }
 
+//TODO use https://blog.golang.org/subtests when removing support for Go1.6
 func benchmarkGetCommitsInfo(url string, b *testing.B) {
 	b.StopTimer()
 	

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const benchmarkReposDir = "benchmark_repos/"
+const benchmarkReposDir = "benchmark/repos/"
 
 func setupGitRepo(url string, name string) (string, error) {
 	repoDir := filepath.Join(benchmarkReposDir, name)

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -38,6 +38,7 @@ func BenchmarkEntries_GetCommitsInfo(b *testing.B) {
 		{url: "https://github.com/torvalds/linux.git", name: "linux"},
 	}
 	for _, benchmark := range benchmarks {
+		b.StopTimer()
 		var commit *Commit
 		var entries Entries
 		if repoPath, err := setupGitRepo(benchmark.url, benchmark.name); err != nil {
@@ -50,6 +51,7 @@ func BenchmarkEntries_GetCommitsInfo(b *testing.B) {
 			panic(err)
 		}
 		entries.Sort()
+		b.StartTimer()
 		b.Run(benchmark.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := entries.GetCommitsInfo(commit, "")

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -65,4 +65,5 @@ func benchmarkGetCommitsInfo(url string, b *testing.B) {
 
 func BenchmarkGetCommitsInfoGitea(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/go-gitea/gitea.git", b) } //5k+ commits
 func BenchmarkGetCommitsInfoMoby(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/moby/moby.git", b) } //32k+ commits
-func BenchmarkGetCommitsInfoGo(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/golang/go.git", b) } //+32k commits
+func BenchmarkGetCommitsInfoGo(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/golang/go.git", b) } //32k+ commits
+func BenchmarkGetCommitsInfoGo(b *testing.B)  { benchmarkGetCommitsInfo("https://github.com/torvalds/linux.git", b) } //677k+ commits

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func setupGitRepo(url string) string {
-	
 	dir, err := ioutil.TempDir("", "gitea-bench")
 	if err != nil {
 		panic(err)
@@ -30,7 +29,8 @@ func setupGitRepo(url string) string {
 }
 
 func benchmarkGetCommitsInfo(url string, b *testing.B) {
-
+	b.StopTimer()
+	
 	// setup env
 	repoPath := setupGitRepo(url)
 	defer os.RemoveAll(repoPath)
@@ -51,6 +51,7 @@ func benchmarkGetCommitsInfo(url string, b *testing.B) {
 	}
 	entries.Sort()
 
+	b.StartTimer()
 	// run the GetCommitsInfo function b.N times
 	for n := 0; n < b.N; n++ {
 		_, err = entries.GetCommitsInfo(commit, "")


### PR DESCRIPTION
A faster implementation of `GetCommitsInfo`, addresses https://github.com/go-gitea/gitea/issues/491 and https://github.com/go-gitea/gitea/issues/502.

The previous implementation made a call to `git log` for each entry, each of which required scanning through the commit history. This new implementation instead makes a single call to `git log`. This is faster, because it involves scanning the commit history only once.

__BENCHMARK RESULTS__:
Shoutout to @sapk for the benchmark tests he wrote (#54), which I have stolen here.

Old implementation:
```
BenchmarkEntries_GetCommitsInfo/gitea-4         	     200	  70670229 ns/op
BenchmarkEntries_GetCommitsInfo/manyfiles-4     	       1	35907609610 ns/op
BenchmarkEntries_GetCommitsInfo/moby-4          	      50	 204585469 ns/op
BenchmarkEntries_GetCommitsInfo/go-4            	      20	 640497304 ns/op
BenchmarkEntries_GetCommitsInfo/linux-4         	      20	 829981474 ns/op
```

New implementation:
```
BenchmarkEntries_GetCommitsInfo/gitea-4         	     500	  34284443 ns/op
BenchmarkEntries_GetCommitsInfo/manyfiles-4     	      30	 424753714 ns/op
BenchmarkEntries_GetCommitsInfo/moby-4          	     100	 109430547 ns/op
BenchmarkEntries_GetCommitsInfo/go-4            	      30	 521336982 ns/op
BenchmarkEntries_GetCommitsInfo/linux-4         	      20	 813171326 ns/op
```

__IMPLEMENTATION DETAILS__:
Gets the 16 latest commits affecting the relevant entries (`git log --name-only -16 HEAD -- <treePath>`). The output of this command containing which files were affect by each commit. Scan through this list of cmmit, and stop once a commit has been found for each entry.

If you go through the first batch of 16 commits, you get then next 32 commits (`git log --name-only -32 <last-commit-from-first-batch>^ -- entry1 entry2 ...`); each time you double the number of commits. This ensures that in the common case you'll only have to read in a small number (16) of commits, but you also won't have to make too many calls to `git log` if you need to go further into the commit history.

Finally, if you are looking for 32 or fewer entries, manually list out each entry in the `git log` command (`git log --name-only -- entry1 entry2...`) to support a more targeted search.