### PR TITLE
Use b.Fatal in benchmark tests

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -51,7 +51,10 @@ THE SOFTWARE.`
 
 func Benchmark_Blob_Data(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		r, _ := testBlob.Data()
+		r, err := testBlob.Data()
+		if err != nil {
+			b.Fatal(err)
+		}
 		ioutil.ReadAll(r)
 	}
 }
@@ -60,6 +63,8 @@ func Benchmark_Blob_DataPipeline(b *testing.B) {
 	stdout := new(bytes.Buffer)
 	for i := 0; i < b.N; i++ {
 		stdout.Reset()
-		testBlob.DataPipeline(stdout, nil)
+		if err := testBlob.DataPipeline(stdout, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/tree_entry_test.go
+++ b/tree_entry_test.go
@@ -42,13 +42,13 @@ func BenchmarkEntries_GetCommitsInfo(b *testing.B) {
 		var commit *Commit
 		var entries Entries
 		if repoPath, err := setupGitRepo(benchmark.url, benchmark.name); err != nil {
-			panic(err)
+			b.Fatal(err)
 		} else if repo, err := OpenRepository(repoPath); err != nil {
-			panic(err)
+			b.Fatal(err)
 		} else if commit, err = repo.GetBranchCommit("master"); err != nil {
-			panic(err)
+			b.Fatal(err)
 		} else if entries, err = commit.Tree.ListEntries(); err != nil {
-			panic(err)
+			b.Fatal(err)
 		}
 		entries.Sort()
 		b.StartTimer()
@@ -56,7 +56,7 @@ func BenchmarkEntries_GetCommitsInfo(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := entries.GetCommitsInfo(commit, "")
 				if err != nil {
-					panic(err)
+					b.Fatal(err)
 				}
 			}
 		})


### PR DESCRIPTION
Use `b.Fatal` instead of `panic` in benchmark tests. Also check for previously-unchecked errors in `blob_test.go`
