### PR TITLE
Return error from cmd.Wait()

### DIFF
--- a/command.go
+++ b/command.go
@@ -71,7 +71,7 @@ func (c *Command) RunInDirTimeoutPipeline(timeout time.Duration, dir string, std
 	}
 
 	if err := cmd.Wait(); err != nil {
-		log("exec.Wait: %v", err)
+		return err
 	}
 
 	return ctx.Err()


### PR DESCRIPTION
Check and return the error returned by `cmd.Wait()`, instead of quietly logging and ignoring.

Ignoring this error, because the subsequent call to `ctx.Err()` may return `nil` even if `cmd.Wait()` returned an actual error. For instance, `git show-ref --verify <non-existent-branch>` will fail with a exit code of 128, and `cmd.Wait()` will return an error, but `cmd.Wait()` will return `nil`.