### PR TITLE
Fix bug in GetCommitInfos

### DIFF
--- a/tree_entry.go
+++ b/tree_entry.go
@@ -266,7 +266,7 @@ func getNextCommitInfos(state *getCommitInfoState) error {
 func logCommand(exclusiveStartHash string, state *getCommitInfoState) *Command {
 	var commitHash string
 	if len(exclusiveStartHash) == 0 {
-		commitHash = "HEAD"
+		commitHash = state.headCommit.ID.String()
 	} else {
 		commitHash = exclusiveStartHash + "^"
 	}


### PR DESCRIPTION
Fix bug from #53. Hard-coding `HEAD` breaks things when you're not on the master branch.

Fixes https://github.com/go-gitea/gitea/issues/1836
