### PR TITLE
Fix parsing bug in GetTagInfos

### DIFF
--- a/repo_tag.go
+++ b/repo_tag.go
@@ -6,7 +6,6 @@ package git
 
 import (
 	"strings"
-	"time"
 
 	"github.com/mcuadros/go-version"
 )
@@ -95,84 +94,36 @@ func (repo *Repository) GetTag(name string) (*Tag, error) {
 	return tag, nil
 }
 
-// TagOption describes tag options
-type TagOption struct {
-}
-
-// parseTag parse the line
-// 2016-10-14 20:54:25 +0200  (tag: translation/20161014.01) d3b76dcf2 Dirk Baeumer dirkb@microsoft.com Merge in translations
-func parseTag(line string, opt TagOption) (*Tag, error) {
-	line = strings.TrimSpace(line)
-	if len(line) < 40 {
-		return nil, nil
-	}
-
-	var (
-		err error
-		tag Tag
-		sig Signature
-	)
-	sig.When, err = time.Parse("2006-01-02 15:04:05 -0700", line[0:25])
-	if err != nil {
-		return nil, err
-	}
-
-	left := strings.TrimSpace(line[25:])
-	start := strings.Index(left, "tag: ")
-	if start < 0 {
-		return nil, nil
-	}
-	end := strings.LastIndexByte(left[start+1:], ')')
-	if end < 0 {
-		return nil, nil
-	}
-	end = end + start + 1
-	part := strings.IndexByte(left[start+5:end], ',')
-	if part > 0 {
-		tag.Name = strings.TrimSpace(left[start+5 : start+5+part])
-	} else {
-		tag.Name = strings.TrimSpace(left[start+5 : end])
-	}
-	next := strings.IndexByte(left[end+2:], ' ')
-	if next < 0 {
-		return nil, nil
-	}
-	tag.Object = MustIDFromString(strings.TrimSpace(left[end+2 : end+2+next]))
-	next = end + 2 + next
-
-	emailStart := strings.IndexByte(left[next:], '<')
-	sig.Name = strings.TrimSpace(left[next:][:emailStart-1])
-	emailEnd := strings.IndexByte(left[next:], '>')
-	sig.Email = strings.TrimSpace(left[next:][emailStart+1 : emailEnd])
-	tag.Tagger = &sig
-	tag.Message = strings.TrimSpace(left[next+emailEnd+1:])
-	return &tag, nil
-}
-
 // GetTagInfos returns all tag infos of the repository.
-func (repo *Repository) GetTagInfos(opt TagOption) ([]*Tag, error) {
-	cmd := NewCommand("log", "--tags", "--simplify-by-decoration", `--pretty=format:"%ci %d %H %cn<%ce> %s"`)
-	stdout, err := cmd.RunInDir(repo.Path)
+func (repo *Repository) GetTagInfos() ([]*Tag, error) {
+	stdout, err := NewCommand("tag").RunInDir(repo.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	tagSlices := strings.Split(stdout, "\n")
+	tagNames := strings.Split(stdout, "\n")
 	var tags []*Tag
-	for _, line := range tagSlices {
-		line := strings.Trim(line, `"`)
-		tag, err := parseTag(line, opt)
+	for _, tagName := range tagNames {
+		tagName = strings.TrimSpace(tagName)
+		if len(tagName) == 0 {
+			continue
+		}
+		commitID, err := NewCommand("rev-parse", tagName).RunInDir(repo.Path)
 		if err != nil {
 			return nil, err
 		}
-		if tag != nil {
-			tag.repo = repo
-			tags = append(tags, tag)
+		commit, err := repo.GetCommit(commitID)
+		if err != nil {
+			return nil, err
 		}
+		tags = append(tags, &Tag{
+			Name:    tagName,
+			Message: commit.Message(),
+			Object:  commit.ID,
+			Tagger:  commit.Author,
+		})
 	}
-
 	sortTagsByTime(tags)
-
 	return tags, nil
 }
 

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -96,6 +96,7 @@ func (repo *Repository) GetTag(name string) (*Tag, error) {
 
 // GetTagInfos returns all tag infos of the repository.
 func (repo *Repository) GetTagInfos() ([]*Tag, error) {
+	// TODO this a slow implementation, makes one git command per tag
 	stdout, err := NewCommand("tag").RunInDir(repo.Path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The previous implementation of `GetTagInfos()` would break when commit messages contained closing parentheses (previous line 125), and would not account for when one commit could have several tags.