### PR TITLE
Fix escaped char bug in getCommitInfos

### DIFF
--- a/tree_entry.go
+++ b/tree_entry.go
@@ -5,6 +5,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -253,6 +254,12 @@ func getNextCommitInfos(state *getCommitInfoState) error {
 			path := lines[i]
 			if path == "" {
 				break
+			}
+			if path[0] == '"' {
+				path, err = strconv.Unquote(path)
+				if err != nil {
+					return fmt.Errorf("Unquote: %v", err)
+				}
 			}
 			state.update(path)
 		}


### PR DESCRIPTION
The filenames in the output of `git log` command may contain escaped characters in quotes (e.g. for files whose name contain backslashes):

```
13d136320bad8b0318c2476a392fafb11b0bcf13
"content\\G44870\\ῥῆμα.md"
```

`getCommitInfos` previously did not for account this; with these changes it does.