### PR TITLE
Use POSIX complaint ! operator in find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ generate:
 
 .PHONY: fmt
 fmt:
-	find . -name "*.go" -type f -not -path "./vendor/*" -not -path "./benchmark/*" | xargs gofmt -s -w
+	find . -name "*.go" -type f ! -path "./vendor/*" ! -path "./benchmark/*" | xargs gofmt -s -w
 
 .PHONY: vet
 vet:


### PR DESCRIPTION
-not is a GNU extension and not all find(8) implementations
support it. It's just an alias for ! which is POSIX compliant.