### PR TITLE
Remove unnecessary version checks

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -12,8 +12,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
-	"github.com/mcuadros/go-version"
 )
 
 // Commit represents a git commit.
@@ -160,13 +158,7 @@ func CommitChanges(repoPath string, opts CommitChangesOptions) error {
 
 func commitsCount(repoPath, revision, relpath string) (int64, error) {
 	var cmd *Command
-	isFallback := false
-	if version.Compare(gitVersion, "1.8.0", "<") {
-		isFallback = true
-		cmd = NewCommand("log", "--pretty=format:''")
-	} else {
-		cmd = NewCommand("rev-list", "--count")
-	}
+	cmd = NewCommand("rev-list", "--count")
 	cmd.AddArguments(revision)
 	if len(relpath) > 0 {
 		cmd.AddArguments("--", relpath)
@@ -177,9 +169,6 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 		return 0, err
 	}
 
-	if isFallback {
-		return int64(strings.Count(stdout, "\n")) + 1, nil
-	}
 	return strconv.ParseInt(strings.TrimSpace(stdout), 10, 64)
 }
 

--- a/repo_branch.go
+++ b/repo_branch.go
@@ -7,8 +7,6 @@ package git
 import (
 	"fmt"
 	"strings"
-
-	"github.com/mcuadros/go-version"
 )
 
 // BranchPrefix base dir of the branch information file store on git
@@ -56,10 +54,6 @@ func (repo *Repository) GetHEADBranch() (*Branch, error) {
 
 // SetDefaultBranch sets default branch of repository.
 func (repo *Repository) SetDefaultBranch(name string) error {
-	if version.Compare(gitVersion, "1.7.10", "<") {
-		return ErrUnsupportedVersion{"1.7.10"}
-	}
-
 	_, err := NewCommand("symbolic-ref", "HEAD", BranchPrefix+name).RunInDir(repo.Path)
 	return err
 }

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/mcuadros/go-version"
 )
 
 // getRefCommitID returns the last commit ID string of given reference (branch or tag).
@@ -248,37 +246,11 @@ func (repo *Repository) FilesCountBetween(startCommitID, endCommitID string) (in
 
 // CommitsBetween returns a list that contains commits between [last, before).
 func (repo *Repository) CommitsBetween(last *Commit, before *Commit) (*list.List, error) {
-	if version.Compare(gitVersion, "1.8.0", ">=") {
-		stdout, err := NewCommand("rev-list", before.ID.String()+"..."+last.ID.String()).RunInDirBytes(repo.Path)
-		if err != nil {
-			return nil, err
-		}
-		return repo.parsePrettyFormatLogToList(bytes.TrimSpace(stdout))
+	stdout, err := NewCommand("rev-list", before.ID.String()+"..."+last.ID.String()).RunInDirBytes(repo.Path)
+	if err != nil {
+		return nil, err
 	}
-
-	// Fallback to stupid solution, which iterates all commits of the repository
-	// if before is not an ancestor of last.
-	l := list.New()
-	if last == nil || last.ParentCount() == 0 {
-		return l, nil
-	}
-
-	var err error
-	cur := last
-	for {
-		if cur.ID.Equal(before.ID) {
-			break
-		}
-		l.PushBack(cur)
-		if cur.ParentCount() == 0 {
-			break
-		}
-		cur, err = cur.Parent(0)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return l, nil
+	return repo.parsePrettyFormatLogToList(bytes.TrimSpace(stdout))
 }
 
 // CommitsBetweenIDs return commits between twoe commits


### PR DESCRIPTION
Since the required git version is set to `1.8.1.6` we can remove some version checks and fallbacks.