### PR TITLE
Refactor CommitsBefore method to match github

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -7,7 +7,6 @@ package git
 import (
 	"bytes"
 	"container/list"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -272,71 +271,60 @@ func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
 }
 
 // commitsBefore the limit is depth, not total number of returned commits.
-func (repo *Repository) commitsBefore(l *list.List, parent *list.Element, id SHA1, current, limit int) error {
-	// Reach the limit
-	if limit > 0 && current > limit {
-		return nil
-	}
-
-	commit, err := repo.getCommit(id)
-	if err != nil {
-		return fmt.Errorf("getCommit: %v", err)
-	}
-
-	var e *list.Element
-	if parent == nil {
-		e = l.PushBack(commit)
+func (repo *Repository) commitsBefore(id SHA1, limit int) (*list.List, error) {
+	cmd := NewCommand("log")
+	if limit > 0 {
+		cmd.AddArguments("-"+ strconv.Itoa(limit), prettyLogFormat, id.String())
 	} else {
-		var in = parent
-		for {
-			if in == nil {
-				break
-			} else if in.Value.(*Commit).ID.Equal(commit.ID) {
-				return nil
-			} else if in.Next() == nil {
-				break
-			}
-
-			if in.Value.(*Commit).Committer.When.Equal(commit.Committer.When) {
-				break
-			}
-
-			if in.Value.(*Commit).Committer.When.After(commit.Committer.When) &&
-				in.Next().Value.(*Commit).Committer.When.Before(commit.Committer.When) {
-				break
-			}
-
-			in = in.Next()
-		}
-
-		e = l.InsertAfter(commit, in)
+		cmd.AddArguments(prettyLogFormat, id.String())
 	}
 
-	pr := parent
-	if commit.ParentCount() > 1 {
-		pr = e
+	stdout, err := cmd.RunInDirBytes(repo.Path)
+	if err != nil {
+		return nil, err
 	}
 
-	for i := 0; i < commit.ParentCount(); i++ {
-		id, err := commit.ParentID(i)
+	formattedLog, err := repo.parsePrettyFormatLogToList(bytes.TrimSpace(stdout))
+	if err != nil {
+		return nil, err
+	}
+
+	commits := list.New()
+	for logEntry := formattedLog.Front(); logEntry != nil; logEntry = logEntry.Next() {
+		commit := logEntry.Value.(*Commit)
+		branches, err := repo.getBranches(commit)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		err = repo.commitsBefore(l, pr, id, current+1, limit)
-		if err != nil {
-			return err
+
+		if len(branches) > 1 {
+			break
 		}
+
+		commits.PushBack(commit)
 	}
 
-	return nil
+	return commits, nil
 }
 
 func (repo *Repository) getCommitsBefore(id SHA1) (*list.List, error) {
-	l := list.New()
-	return l, repo.commitsBefore(l, nil, id, 1, 0)
+	return repo.commitsBefore(id, 0)
 }
 
 func (repo *Repository) getCommitsBeforeLimit(id SHA1, num int) (*list.List, error) {
-	l := list.New()
-	return l, repo.commitsBefore(l, nil, id, 1, num)
+	return repo.commitsBefore(id, num)
+}
+
+func (repo *Repository) getBranches(commit *Commit) ([]string, error) {
+	stdout, err := NewCommand("for-each-ref", "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := strings.Split(stdout, "\n")
+	branches := make([]string, len(refs)-1)
+	for i, ref := range refs[:len(refs)-1] {
+		branches[i] = strings.TrimPrefix(ref, BranchPrefix)
+	}
+	return branches, nil
 }

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -292,7 +292,7 @@ func (repo *Repository) commitsBefore(id SHA1, limit int) (*list.List, error) {
 	commits := list.New()
 	for logEntry := formattedLog.Front(); logEntry != nil; logEntry = logEntry.Next() {
 		commit := logEntry.Value.(*Commit)
-		branches, err := repo.getBranches(commit)
+		branches, err := repo.getBranches(commit, 2)
 		if err != nil {
 			return nil, err
 		}
@@ -315,8 +315,8 @@ func (repo *Repository) getCommitsBeforeLimit(id SHA1, num int) (*list.List, err
 	return repo.commitsBefore(id, num)
 }
 
-func (repo *Repository) getBranches(commit *Commit) ([]string, error) {
-	stdout, err := NewCommand("for-each-ref", "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
+func (repo *Repository) getBranches(commit *Commit, limit int) ([]string, error) {
+	stdout, err := NewCommand("for-each-ref", "--count="+ strconv.Itoa(limit), "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The CommitsBefore method is `only` used to retrieve commits for the push webhook if a new branch is pushed.
Namely at https://github.com/go-gitea/gitea/blob/a4cd4616c6f8524f8eb79d6184e855b3a8164130/models/update.go#L229

The refactored method now returns exactly those commits which were added in the new branch and are not existing in any other branch.
This result now behaves exactly as github (compared to the webhook result) except for the order.

The order will be fixed in a separate PR as there is another method which needs order fixing.
All these changes are necessary to implement https://github.com/go-gitea/gitea/pull/2548