### PR TITLE
Accept git 1.7.2 as the minimum version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@ pipeline:
     image: webhippie/golang:edge
     pull: true
     commands:
+      - git update-ref refs/heads/test HEAD
       - make clean
       - make vet
       - make lint

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,7 @@ pipeline:
     image: docker.kbt.io/gitea-git-ci:1.7
     pull: true
     commands:
+      - git update-ref refs/heads/test HEAD
       - PATH=/opt/git-1.7.2/bin git --version && make test
 
   # coverage:

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,24 +10,24 @@ clone:
     tags: true
 
 pipeline:
+  test-general:
+    image: webhippie/golang:edge
+    pull: true
+    commands:
+      - make clean
+      - make vet
+      - make lint
+      - make build
   testing-git-latest:
     image: webhippie/golang:edge
     pull: true
     commands:
       - git update-ref refs/heads/test HEAD
-      - make clean
-      - make vet
-      - make lint
       - git --version && make test
-      - make build
   testing-git-1.7:
     image: docker.kbt.io/gitea-git-ci:1.7
     pull: true
     commands:
-      - git update-ref refs/heads/test HEAD
-      - make clean
-      - make vet
-      - make lint
       - PATH=/opt/git-1.7.2/bin git --version && make test
 
   # coverage:

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ clone:
     tags: true
 
 pipeline:
-  testing:
+  testing-git-latest:
     image: webhippie/golang:edge
     pull: true
     commands:
@@ -18,24 +18,17 @@ pipeline:
       - make clean
       - make vet
       - make lint
-      # Test with latest git version
       - git --version && make test
-      # Test with git version 1.7.2
-      - apk add --update autoconf zlib-dev > /dev/null &&
-        mkdir build &&
-        curl -sL "https://github.com/git/git/archive/v1.7.2.tar.gz" -o git.tar.gz &&
-        tar -C build -xzf git.tar.gz &&
-        cd build/git-1.7.2 &&
-        { autoconf 2> err || { cat err && false; } } &&
-        ./configure --without-tcltk --prefix=/usr/local > /dev/null &&
-        { make install NO_PERL=please > /dev/null 2> err || { cat err && false; } } &&
-        cd ../.. &&
-        rm -rf build git.tar.gz &&
-        hash -r &&
-        git --version &&
-        make test
-      # Test a build (is this really needed?)
       - make build
+  testing-git-1.7:
+    image: docker.kbt.io/gitea-git-ci:1.7
+    pull: true
+    commands:
+      - git update-ref refs/heads/test HEAD
+      - make clean
+      - make vet
+      - make lint
+      - PATH=/opt/git-1.7.2/bin git --version && make test
 
   # coverage:
   #   image: plugins/coverage:1

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,23 +18,23 @@ pipeline:
       - make clean
       - make vet
       - make lint
-      - git --version
-      - make test
-      - apk add --update autoconf &&
-        apk add --update zlib-dev &&
+      # Test with latest git version
+      - git --version && make test
+      # Test with git version 1.7.2
+      - apk add --update autoconf zlib-dev > /dev/null &&
         mkdir build &&
         curl -sL "https://github.com/git/git/archive/v1.7.2.tar.gz" -o git.tar.gz &&
         tar -C build -xzf git.tar.gz &&
         cd build/git-1.7.2 &&
-        autoconf &&
-        ./configure --without-tcltk --prefix=/usr/local &&
-        make install NO_PERL=please &&
+        { autoconf 2> err || cat err; } &&
+        ./configure --without-tcltk --prefix=/usr/local > /dev/null &&
+        { make install NO_PERL=please > /dev/null 2> err || cat err; } &&
         cd ../.. &&
-        rm -rf build &&
-        rm git.tar.gz
-      - hash -r
-      - git --version
-      - make test
+        rm -rf build git.tar.gz &&
+        hash -r &&
+        git --version &&
+        make test
+      # Test a build (is this really needed?)
       - make build
 
   # coverage:

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,9 +26,9 @@ pipeline:
         curl -sL "https://github.com/git/git/archive/v1.7.2.tar.gz" -o git.tar.gz &&
         tar -C build -xzf git.tar.gz &&
         cd build/git-1.7.2 &&
-        { autoconf 2> err || cat err; } &&
+        { autoconf 2> err || { cat err && false; } } &&
         ./configure --without-tcltk --prefix=/usr/local > /dev/null &&
-        { make install NO_PERL=please > /dev/null 2> err || cat err; } &&
+        { make install NO_PERL=please > /dev/null 2> err || { cat err && false; } } &&
         cd ../.. &&
         rm -rf build git.tar.gz &&
         hash -r &&

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,6 +18,22 @@ pipeline:
       - make clean
       - make vet
       - make lint
+      - git --version
+      - make test
+      - apk add --update autoconf &&
+        apk add --update zlib-dev &&
+        mkdir build &&
+        curl -sL "https://github.com/git/git/archive/v1.7.2.tar.gz" -o git.tar.gz &&
+        tar -C build -xzf git.tar.gz &&
+        cd build/git-1.7.2 &&
+        autoconf &&
+        ./configure --without-tcltk --prefix=/usr/local &&
+        make install NO_PERL=please &&
+        cd ../.. &&
+        rm -rf build &&
+        rm git.tar.gz
+      - hash -r
+      - git --version
       - make test
       - make build
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -1,0 +1,15 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitsCount(t *testing.T) {
+	commitsCount, _ := CommitsCount(".", "d86a90f801dbe279db095437a8c7ea42c60e8d98")
+	assert.Equal(t, int64(3), commitsCount)
+}

--- a/docker/ci/Dockerfile-git-1.7
+++ b/docker/ci/Dockerfile-git-1.7
@@ -1,0 +1,11 @@
+FROM webhippie/golang:edge
+RUN apk add --update autoconf zlib-dev > /dev/null && \
+    mkdir build && \
+    curl -sL "https://github.com/git/git/archive/v1.7.2.tar.gz" -o git.tar.gz && \
+    tar -C build -xzf git.tar.gz && \
+    cd build/git-1.7.2 && \
+    { autoconf 2> err || { cat err && false; } } && \
+    ./configure --without-tcltk --prefix=/opt/git-1.7.2 > /dev/null && \
+    { make install NO_PERL=please > /dev/null 2> err || { cat err && false; } } && \
+    cd ../.. && \
+    rm -rf build git.tar.gz \

--- a/docker/ci/Makefile
+++ b/docker/ci/Makefile
@@ -1,0 +1,2 @@
+git-1.7:
+	docker build -t gitea/ci:git-1.7 -f Dockerfile-git-1.7 .

--- a/git.go
+++ b/git.go
@@ -25,7 +25,7 @@ var (
 	// Prefix the log prefix
 	Prefix = "[git-module] "
 	// GitVersionRequired is the minimum Git version required
-	GitVersionRequired = "1.8.1.6"
+	GitVersionRequired = "1.7.2"
 )
 
 func log(format string, args ...interface{}) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -1,0 +1,25 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLatestCommitTime(t *testing.T) {
+	lct, err := GetLatestCommitTime(".")
+	assert.NoError(t, err)
+	// Time is in the past
+	now := time.Now()
+	assert.True(t, lct.Unix() < now.Unix(), "%d not smaller than %d", lct, now)
+	// Time is after Mon Oct 23 03:52:09 2017 +0300
+	// which is the time of commit
+	// d47b98c44c9a6472e44ab80efe65235e11c6da2a
+	refTime, err := time.Parse("Mon Jan 02 15:04:05 2006 -0700", "Mon Oct 23 03:52:09 2017 +0300")
+	assert.NoError(t, err)
+	assert.True(t, lct.Unix() > refTime.Unix(), "%d not greater than %d", lct, refTime)
+}


### PR DESCRIPTION
Debian old old (very old) distribution (6.0 aka Squeeze)
ships version 1.7.10.4.

The version requirement was raised in #46 supposedly for the
need of "symbolic-ref" command, but that command is supported
by the 1.7 version too, and even older versions.