### PR TITLE
Fix time parsing

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -283,5 +283,5 @@ func GetLatestCommitTime(repoPath string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	commitTime := strings.TrimSpace(stdout)
-	return time.Parse("Mon Jan 02 15:04:05 2006 -0700", commitTime)
+	return time.Parse(GitTimeLayout, commitTime)
 }

--- a/signature.go
+++ b/signature.go
@@ -17,6 +17,11 @@ type Signature struct {
 	When  time.Time
 }
 
+const (
+	// GitTimeLayout is the (default) time layout used by git.
+	GitTimeLayout = "Mon Jan _2 15:04:05 2006 -0700"
+)
+
 // Helper to get a signature from the commit line, which looks like these:
 //     author Patrick Gundlach <gundlach@speedata.de> 1378823654 +0200
 //     author Patrick Gundlach <gundlach@speedata.de> Thu, 07 Apr 2005 22:13:13 +0200
@@ -40,7 +45,7 @@ func newSignatureFromCommitline(line []byte) (_ *Signature, err error) {
 			seconds, _ := strconv.ParseInt(timestring, 10, 64)
 			sig.When = time.Unix(seconds, 0)
 		} else {
-			sig.When, err = time.Parse("Mon Jan _2 15:04:05 2006 -0700", string(line[emailEnd+2:]))
+			sig.When, err = time.Parse(GitTimeLayout, string(line[emailEnd+2:]))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fix time parsing in `GetLatestCommitTime`, which would fail on days 1-9 of the month (since the date only has one digit, see below output). Also moves the time format to a named constant, since it is used in multiple places.

```
--- FAIL: TestGetLatestCommitTime (0.00s)
        Error Trace:    repo_test.go:15
	Error:		Received unexpected error:
			parsing time "Sat Dec 9 17:17:57 2017 -0800" as "Mon Jan 02 15:04:05 2006 -0700": cannot parse "9 17:17:57 2017 -0800" as "02"
```