### PR TITLE
Fix tree entry parsing

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// ParseTreeEntries parses the output of a `git ls-tree` command.
+func ParseTreeEntries(data []byte) ([]*TreeEntry, error) {
+	entries := make([]*TreeEntry, 0, 10)
+	l := len(data)
+	pos := 0
+	for pos < l {
+		// expect line to be of the form "<mode> <type> <sha>\t<filename>"
+		entry := new(TreeEntry)
+		if pos+6 > len(data) {
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
+		}
+		switch string(data[pos : pos+6]) {
+		case "100644":
+			entry.mode = EntryModeBlob
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "100644 blob "
+		case "100755":
+			entry.mode = EntryModeExec
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "100755 blob "
+		case "120000":
+			entry.mode = EntryModeSymlink
+			entry.Type = ObjectBlob
+			pos += 12 // skip over "120000 blob "
+		case "160000":
+			entry.mode = EntryModeCommit
+			entry.Type = ObjectCommit
+			pos += 14 // skip over "160000 object "
+		case "040000":
+			entry.mode = EntryModeTree
+			entry.Type = ObjectTree
+			pos += 12 // skip over "040000 tree "
+		default:
+			return nil, fmt.Errorf("unknown type: %v", string(data[pos:pos+6]))
+		}
+
+		if pos+40 > len(data) {
+			return nil, fmt.Errorf("Truncated ls-tree output: %s", string(data))
+		}
+		id, err := NewIDFromString(string(data[pos : pos+40]))
+		if err != nil {
+			return nil, err
+		}
+		entry.ID = id
+		pos += 41 // skip over sha and trailing space
+
+		end := pos + bytes.IndexByte(data[pos:], '\n')
+		if end < pos {
+			return nil, fmt.Errorf("Truncated ls-tree output: %s", string(data))
+		}
+
+		// In case entry name is surrounded by double quotes(it happens only in git-shell).
+		if data[pos] == '"' {
+			entry.name, err = strconv.Unquote(string(data[pos:end]))
+			if err != nil {
+				return nil, fmt.Errorf("Invalid ls-tree output: %v", err)
+			}
+		} else {
+			entry.name = string(data[pos:end])
+		}
+
+		pos = end + 1
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}

--- a/parse.go
+++ b/parse.go
@@ -12,10 +12,15 @@ import (
 
 // ParseTreeEntries parses the output of a `git ls-tree` command.
 func ParseTreeEntries(data []byte) ([]*TreeEntry, error) {
+	return parseTreeEntries(data, nil)
+}
+
+func parseTreeEntries(data []byte, ptree *Tree) ([]*TreeEntry, error) {
 	entries := make([]*TreeEntry, 0, 10)
 	for pos := 0; pos < len(data); {
 		// expect line to be of the form "<mode> <type> <sha>\t<filename>"
 		entry := new(TreeEntry)
+		entry.ptree = ptree
 		if pos+6 > len(data) {
 			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
 		}

--- a/parse.go
+++ b/parse.go
@@ -13,9 +13,7 @@ import (
 // ParseTreeEntries parses the output of a `git ls-tree` command.
 func ParseTreeEntries(data []byte) ([]*TreeEntry, error) {
 	entries := make([]*TreeEntry, 0, 10)
-	l := len(data)
-	pos := 0
-	for pos < l {
+	for pos := 0; pos < len(data); {
 		// expect line to be of the form "<mode> <type> <sha>\t<filename>"
 		entry := new(TreeEntry)
 		if pos+6 > len(data) {
@@ -47,18 +45,18 @@ func ParseTreeEntries(data []byte) ([]*TreeEntry, error) {
 		}
 
 		if pos+40 > len(data) {
-			return nil, fmt.Errorf("Truncated ls-tree output: %s", string(data))
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
 		}
 		id, err := NewIDFromString(string(data[pos : pos+40]))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Invalid ls-tree output: %v", err)
 		}
 		entry.ID = id
 		pos += 41 // skip over sha and trailing space
 
 		end := pos + bytes.IndexByte(data[pos:], '\n')
 		if end < pos {
-			return nil, fmt.Errorf("Truncated ls-tree output: %s", string(data))
+			return nil, fmt.Errorf("Invalid ls-tree output: %s", string(data))
 		}
 
 		// In case entry name is surrounded by double quotes(it happens only in git-shell).

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTreeEntries(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected []*TreeEntry
+	}{
+		{
+			Input:    "",
+			Expected: []*TreeEntry{},
+		},
+		{
+			Input: "100644 blob 61ab7345a1a3bbc590068ccae37b8515cfc5843c\texample/file2.txt\n",
+			Expected: []*TreeEntry{
+				{
+					mode: EntryModeBlob,
+					Type: ObjectBlob,
+					ID:   MustIDFromString("61ab7345a1a3bbc590068ccae37b8515cfc5843c"),
+					name: "example/file2.txt",
+				},
+			},
+		},
+		{
+			Input: "120000 blob 61ab7345a1a3bbc590068ccae37b8515cfc5843c\t\"example/\\n.txt\"\n" +
+				"040000 tree 1d01fb729fb0db5881daaa6030f9f2d3cd3d5ae8\texample\n",
+			Expected: []*TreeEntry{
+				{
+					ID:   MustIDFromString("61ab7345a1a3bbc590068ccae37b8515cfc5843c"),
+					Type: ObjectBlob,
+					mode: EntryModeSymlink,
+					name: "example/\n.txt",
+				},
+				{
+					ID:   MustIDFromString("1d01fb729fb0db5881daaa6030f9f2d3cd3d5ae8"),
+					Type: ObjectTree,
+					mode: EntryModeTree,
+					name: "example",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		entries, err := ParseTreeEntries([]byte(testCase.Input))
+		assert.NoError(t, err)
+		assert.EqualValues(t, testCase.Expected, entries)
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -5,8 +5,6 @@
 package git
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 )
 
@@ -28,84 +26,6 @@ func NewTree(repo *Repository, id SHA1) *Tree {
 		ID:   id,
 		repo: repo,
 	}
-}
-
-var escapeChar = []byte("\\")
-
-// UnescapeChars reverses escaped characters.
-func UnescapeChars(in []byte) []byte {
-	if bytes.Index(in, escapeChar) == -1 {
-		return in
-	}
-
-	endIdx := len(in) - 1
-	isEscape := false
-	out := make([]byte, 0, endIdx+1)
-	for i := range in {
-		if in[i] == '\\' && !isEscape {
-			isEscape = true
-			continue
-		}
-		isEscape = false
-		out = append(out, in[i])
-	}
-	return out
-}
-
-// parseTreeData parses tree information from the (uncompressed) raw
-// data from the tree object.
-func parseTreeData(tree *Tree, data []byte) ([]*TreeEntry, error) {
-	entries := make([]*TreeEntry, 0, 10)
-	l := len(data)
-	pos := 0
-	for pos < l {
-		entry := new(TreeEntry)
-		entry.ptree = tree
-		step := 6
-		switch string(data[pos : pos+step]) {
-		case "100644":
-			entry.mode = EntryModeBlob
-			entry.Type = ObjectBlob
-		case "100755":
-			entry.mode = EntryModeExec
-			entry.Type = ObjectBlob
-		case "120000":
-			entry.mode = EntryModeSymlink
-			entry.Type = ObjectBlob
-		case "160000":
-			entry.mode = EntryModeCommit
-			entry.Type = ObjectCommit
-
-			step = 8
-		case "040000":
-			entry.mode = EntryModeTree
-			entry.Type = ObjectTree
-		default:
-			return nil, fmt.Errorf("unknown type: %v", string(data[pos:pos+step]))
-		}
-		pos += step + 6 // Skip string type of entry type.
-
-		step = 40
-		id, err := NewIDFromString(string(data[pos : pos+step]))
-		if err != nil {
-			return nil, err
-		}
-		entry.ID = id
-		pos += step + 1 // Skip half of SHA1.
-
-		step = bytes.IndexByte(data[pos:], '\n')
-
-		// In case entry name is surrounded by double quotes(it happens only in git-shell).
-		if data[pos] == '"' {
-			entry.name = string(UnescapeChars(data[pos+1 : pos+step-1]))
-		} else {
-			entry.name = string(data[pos : pos+step])
-		}
-
-		pos += step + 1
-		entries = append(entries, entry)
-	}
-	return entries, nil
 }
 
 // SubTree get a sub tree by the sub dir path
@@ -142,12 +62,18 @@ func (t *Tree) ListEntries() (Entries, error) {
 	if t.entriesParsed {
 		return t.entries, nil
 	}
-	t.entriesParsed = true
 
 	stdout, err := NewCommand("ls-tree", t.ID.String()).RunInDirBytes(t.repo.Path)
 	if err != nil {
 		return nil, err
 	}
-	t.entries, err = parseTreeData(t, stdout)
+	t.entries, err = ParseTreeEntries(stdout)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range t.entries {
+		entry.ptree = t
+	}
+	t.entriesParsed = true
 	return t.entries, err
 }

--- a/tree.go
+++ b/tree.go
@@ -67,13 +67,6 @@ func (t *Tree) ListEntries() (Entries, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.entries, err = ParseTreeEntries(stdout)
-	if err != nil {
-		return nil, err
-	}
-	for _, entry := range t.entries {
-		entry.ptree = t
-	}
-	t.entriesParsed = true
+	t.entries, err = parseTreeEntries(stdout, t)
 	return t.entries, err
 }


### PR DESCRIPTION
Fixes the parsing of filenames with escaped characters, which did not previously handled escaped characters such as `\n` correctly. Also adds unit tests.

This PR also exposes the parsing functionality as public, so that it can be reused (see https://github.com/go-gitea/gitea/blob/a89592d4abfef01e68e3c53a3cdb3846b03abd2b/models/repo_indexer.go#L234)