### PR TITLE
GetCommit() returns a ErrNotExist if short commit ID does not exists

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -125,6 +125,9 @@ func (repo *Repository) GetCommit(commitID string) (*Commit, error) {
 		var err error
 		commitID, err = NewCommand("rev-parse", commitID).RunInDir(repo.Path)
 		if err != nil {
+			if strings.Contains(err.Error(), "fatal: ambiguous argument") {
+				return nil, ErrNotExist{commitID, ""}
+			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Currently, GetCommit() returns a generic error if a short commit ID
does not exists in a repository.

When a commit is not found by git-rev-parse, it returns an errors
which contains "fatal: ambiguous argument". GetCommit() now search if
the error contains this string, and, if it does, returns an
ErrNotExist.

The idea is to allow commits to be accessed from gitea with a short
commit ID.  Without this change, it would return a 500 Internal Server
Error when a short ID does not exists in the repository.