### PR TITLE
fix git version below 2.7

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -6,6 +6,7 @@ package git
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -9,6 +9,7 @@ import (
 	"container/list"
 	"strconv"
 	"strings"
+
 	"github.com/mcuadros/go-version"
 )
 
@@ -275,7 +276,7 @@ func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
 func (repo *Repository) commitsBefore(id SHA1, limit int) (*list.List, error) {
 	cmd := NewCommand("log")
 	if limit > 0 {
-		cmd.AddArguments("-"+ strconv.Itoa(limit), prettyLogFormat, id.String())
+		cmd.AddArguments("-"+strconv.Itoa(limit), prettyLogFormat, id.String())
 	} else {
 		cmd.AddArguments(prettyLogFormat, id.String())
 	}
@@ -318,7 +319,7 @@ func (repo *Repository) getCommitsBeforeLimit(id SHA1, num int) (*list.List, err
 
 func (repo *Repository) getBranches(commit *Commit, limit int) ([]string, error) {
 	if version.Compare(gitVersion, "2.7.0", ">=") {
-		stdout, err := NewCommand("for-each-ref", "--count="+ strconv.Itoa(limit), "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
+		stdout, err := NewCommand("for-each-ref", "--count="+strconv.Itoa(limit), "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +343,7 @@ func (repo *Repository) getBranches(commit *Commit, limit int) ([]string, error)
 	if len(refs) > limit {
 		max = limit
 	} else {
-		max = len(refs)-1
+		max = len(refs) - 1
 	}
 
 	branches := make([]string, max)

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -319,16 +319,12 @@ func (repo *Repository) getCommitsBeforeLimit(id SHA1, num int) (*list.List, err
 
 func (repo *Repository) getBranches(commit *Commit, limit int) ([]string, error) {
 	if version.Compare(gitVersion, "2.7.0", ">=") {
-		stdout, err := NewCommand("for-each-ref", "--count="+strconv.Itoa(limit), "--format=%(refname)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
+		stdout, err := NewCommand("for-each-ref", "--count="+strconv.Itoa(limit), "--format=%(refname:strip=2)", "--contains", commit.ID.String(), BranchPrefix).RunInDir(repo.Path)
 		if err != nil {
 			return nil, err
 		}
 
-		refs := strings.Split(stdout, "\n")
-		branches := make([]string, len(refs)-1)
-		for i, ref := range refs[:len(refs)-1] {
-			branches[i] = strings.TrimPrefix(ref, BranchPrefix)
-		}
+		branches := strings.Fields(stdout)
 		return branches, nil
 	}
 

--- a/repo_commit_test.go
+++ b/repo_commit_test.go
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-
 package git
 
 import (
-	"testing"
 	"path/filepath"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/repo_commit_test.go
+++ b/repo_commit_test.go
@@ -1,0 +1,33 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"path/filepath"
+)
+
+func TestRepository_GetBranches(t *testing.T) {
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+	bareRepo1, err := OpenRepository(bareRepo1Path)
+	assert.NoError(t, err)
+
+	// these test case are specific to the repo1_bare test repo
+	testCases := []struct {
+		CommitID         string
+		ExpectedBranches []string
+	}{
+		{"2839944139e0de9737a044f78b0e4b40d989a9e3", []string{"branch1"}},
+		{"5c80b0245c1c6f8343fa418ec374b13b5d4ee658", []string{"branch2"}},
+		{"37991dec2c8e592043f47155ce4808d4580f9123", []string{"master"}},
+		{"95bb4d39648ee7e325106df01a621c530863a653", []string{"branch1", "branch2"}},
+		{"8d92fc957a4d7cfd98bc375f0b7bb189a0d6c9f2", []string{"branch2", "master"}},
+	}
+	for _, testCase := range testCases {
+		commit, err := bareRepo1.GetCommit(testCase.CommitID)
+		assert.NoError(t, err)
+		branches, err := bareRepo1.getBranches(commit, 2)
+		assert.NoError(t, err)
+		assert.Equal(t, testCase.ExpectedBranches, branches)
+	}
+}

--- a/repo_commit_test.go
+++ b/repo_commit_test.go
@@ -1,10 +1,15 @@
+// Copyright 2018 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+
 package git
 
 import (
 	"testing"
+	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
-	"path/filepath"
 )
 
 func TestRepository_GetBranches(t *testing.T) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -7,6 +7,7 @@ package git
 import (
 	"testing"
 	"time"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Targets https://github.com/go-gitea/gitea/issues/3458

Should fix `commitsBefore` for older git versions.