### PR TITLE
limit commit count to improve performance on large repositories

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -161,9 +161,12 @@ func CommitChanges(repoPath string, opts CommitChangesOptions) error {
 	return err
 }
 
-func commitsCount(repoPath, revision, relpath string) (int64, error) {
+func commitsCount(repoPath, revision, relpath string, max int) (int64, error) {
 	var cmd *Command
 	cmd = NewCommand("rev-list", "--count")
+	if max > 0 {
+		cmd.AddArguments("--max-count", strconv.Itoa(max))
+	}
 	cmd.AddArguments(revision)
 	if len(relpath) > 0 {
 		cmd.AddArguments("--", relpath)
@@ -178,13 +181,13 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 }
 
 // CommitsCount returns number of total commits of until given revision.
-func CommitsCount(repoPath, revision string) (int64, error) {
-	return commitsCount(repoPath, revision, "")
+func CommitsCount(repoPath, revision string, max int) (int64, error) {
+	return commitsCount(repoPath, revision, "", max)
 }
 
 // CommitsCount returns number of total commits of until current revision.
-func (c *Commit) CommitsCount() (int64, error) {
-	return CommitsCount(c.repo.Path, c.ID.String())
+func (c *Commit) CommitsCount(max int) (int64, error) {
+	return CommitsCount(c.repo.Path, c.ID.String(), max)
 }
 
 // CommitsByRange returns the specific page commits before current revision, every page's number default by CommitsRangeSize

--- a/commit_test.go
+++ b/commit_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCommitsCount(t *testing.T) {
-	commitsCount, _ := CommitsCount(".", "d86a90f801dbe279db095437a8c7ea42c60e8d98")
+	commitsCount, _ := CommitsCount(".", "d86a90f801dbe279db095437a8c7ea42c60e8d98", 0)
 	assert.Equal(t, int64(3), commitsCount)
 }
 

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -235,8 +235,8 @@ func (repo *Repository) getFilesChanged(id1 string, id2 string) ([]string, error
 }
 
 // FileCommitsCount return the number of files at a revison
-func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
-	return commitsCount(repo.Path, revision, file)
+func (repo *Repository) FileCommitsCount(revision, file string, max int) (int64, error) {
+	return commitsCount(repo.Path, revision, file, max)
 }
 
 // CommitsByFileAndRange return the commits accroding revison file and the page
@@ -281,8 +281,8 @@ func (repo *Repository) CommitsBetweenIDs(last, before string) (*list.List, erro
 }
 
 // CommitsCountBetween return numbers of commits between two commits
-func (repo *Repository) CommitsCountBetween(start, end string) (int64, error) {
-	return commitsCount(repo.Path, start+"..."+end, "")
+func (repo *Repository) CommitsCountBetween(start, end string, max int) (int64, error) {
+	return commitsCount(repo.Path, start+"..."+end, "", max)
 }
 
 // commitsBefore the limit is depth, not total number of returned commits.


### PR DESCRIPTION
limit commit count to improve performance on large repositories