### PR TITLE
command: fix NewCommand

### DIFF
--- a/command.go
+++ b/command.go
@@ -37,9 +37,12 @@ func (c *Command) String() string {
 
 // NewCommand creates and returns a new Git Command based on given command and arguments.
 func NewCommand(args ...string) *Command {
+	// Make an explicit copy of GlobalCommandArgs, otherwise append might overwrite it
+	cargs := make([]string, len(GlobalCommandArgs))
+	copy(cargs, GlobalCommandArgs)
 	return &Command{
 		name: "git",
-		args: append(GlobalCommandArgs, args...),
+		args: append(cargs, args...),
 	}
 }
 


### PR DESCRIPTION
Make an explicit copy of GlobalCommandArgs, otherwise append might overwrite it.

My recent PR for Gitea (https://github.com/go-gitea/gitea/pull/5367) exposed a bug that caused wrong commands to be executed:
```
[...ules/context/repo.go:364 func1()] [E] GetTags: exit status 129 - error: unknown option `sort=-v:refname'
usage: git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -p | <type> | --textconv | --filters) [--path=<path>] <object>
```
(`--sort` is an argument for `tag`, not for `cat-file`.)

The problem seems to be that GlobalCommandArgs is changed by append, which triggers this behavior.