### PR TITLE
get branch commit belongs to

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -18,6 +18,7 @@ import (
 
 // Commit represents a git commit.
 type Commit struct {
+	Branch string // Branch this commit belongs to
 	Tree
 	ID            SHA1 // The ID of this commit object
 	Author        *Signature

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mcuadros/go-version"
+	version "github.com/mcuadros/go-version"
 )
 
 // GetRefCommitID returns the last commit ID string of given reference (branch or tag).
@@ -129,6 +129,14 @@ func (repo *Repository) getCommit(id SHA1) (*Commit, error) {
 	}
 	commit.repo = repo
 	commit.ID = id
+
+	data, err = NewCommand("name-rev", id.String()).RunInDirBytes(repo.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	// name-rev commitID ouput will be "COMMIT_ID master" or "COMMIT_ID master~12"
+	commit.Branch = strings.Split(strings.Split(string(data), " ")[1], "~")[0]
 
 	repo.commitCache.Set(id.String(), commit)
 	return commit, nil


### PR DESCRIPTION
This allows us to get the branch a commit belongs to. 

If commit `oooo` is on `master` and `a_feature_branch`, it defaults to `master` as the result. I have gone through GitHub's implementation and it is the same. Here is an example, https://github.com/go-gitea/gitea/commit/7cb1d8296dbb35fa9b76666fc741bcb129467cd7 exists on `master` and `release/v1.7` but it defaults to showing `master`

Needed to fix https://github.com/go-gitea/gitea/issues/5473

