### PR TITLE
add last commit cache interface

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,11 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package git
+
+// LastCommitCache cache
+type LastCommitCache interface {
+	Get(repoPath, ref, entryPath string) (*Commit, error)
+	Put(repoPath, ref, entryPath string, commit *Commit) error
+}

--- a/commit_info_test.go
+++ b/commit_info_test.go
@@ -51,7 +51,7 @@ func testGetCommitsInfo(t *testing.T, repo1 *Repository) {
 		assert.NoError(t, err)
 		entries, err := tree.ListEntries()
 		assert.NoError(t, err)
-		commitsInfo, err := entries.GetCommitsInfo(commit, testCase.Path)
+		commitsInfo, err := entries.GetCommitsInfo(commit, testCase.Path, nil)
 		assert.NoError(t, err)
 		assert.Len(t, commitsInfo, len(testCase.ExpectedIDs))
 		for _, commitInfo := range commitsInfo {
@@ -106,7 +106,7 @@ func BenchmarkEntries_GetCommitsInfo(b *testing.B) {
 		b.ResetTimer()
 		b.Run(benchmark.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := entries.GetCommitsInfo(commit, "")
+				_, err := entries.GetCommitsInfo(commit, "", nil)
 				if err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
Add a new interface for cache entrypath's last commit info for a special commit's git tree entries.