### PR TITLE
fix bug when get tag id

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -32,7 +32,14 @@ func (repo *Repository) GetBranchCommitID(name string) (string, error) {
 
 // GetTagCommitID returns last commit ID string of given tag.
 func (repo *Repository) GetTagCommitID(name string) (string, error) {
-	return repo.GetRefCommitID(TagPrefix + name)
+	stdout, err := NewCommand("rev-list", "-n", "1", name).RunInDir(repo.Path)
+	if err != nil {
+		if strings.Contains(err.Error(), "unknown revision or path") {
+			return "", ErrNotExist{name, ""}
+		}
+		return "", err
+	}
+	return strings.TrimSpace(stdout), nil
 }
 
 // parseCommitData parses commit information from the (uncompressed) raw

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -76,12 +76,12 @@ func (repo *Repository) getTag(id SHA1) (*Tag, error) {
 
 // GetTag returns a Git tag by given name.
 func (repo *Repository) GetTag(name string) (*Tag, error) {
-	stdout, err := NewCommand("rev-list", "-n", "1", name).RunInDir(repo.Path)
+	idStr, err := repo.GetTagCommitID(name)
 	if err != nil {
 		return nil, err
 	}
 
-	id, err := NewIDFromString(strings.TrimSpace(stdout))
+	id, err := NewIDFromString(idStr)
 	if err != nil {
 		return nil, err
 	}

--- a/repo_tag.go
+++ b/repo_tag.go
@@ -76,12 +76,12 @@ func (repo *Repository) getTag(id SHA1) (*Tag, error) {
 
 // GetTag returns a Git tag by given name.
 func (repo *Repository) GetTag(name string) (*Tag, error) {
-	stdout, err := NewCommand("show-ref", "--tags", name).RunInDir(repo.Path)
+	stdout, err := NewCommand("rev-list", "-n", "1", name).RunInDir(repo.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	id, err := NewIDFromString(strings.Split(stdout, " ")[0])
+	id, err := NewIDFromString(strings.TrimSpace(stdout))
 	if err != nil {
 		return nil, err
 	}

--- a/repo_tag_test.go
+++ b/repo_tag_test.go
@@ -20,7 +20,7 @@ func TestRepository_GetTags(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, tags, 1)
 	assert.EqualValues(t, "test", tags[0].Name)
-	assert.EqualValues(t, "3ad28a9149a2864384548f3d17ed7f38014c9e8a", tags[0].ID.String())
+	assert.EqualValues(t, "37991dec2c8e592043f47155ce4808d4580f9123", tags[0].ID.String())
 	assert.EqualValues(t, "commit", tags[0].Type)
 }
 

--- a/repo_tag_test.go
+++ b/repo_tag_test.go
@@ -23,3 +23,16 @@ func TestRepository_GetTags(t *testing.T) {
 	assert.EqualValues(t, "3ad28a9149a2864384548f3d17ed7f38014c9e8a", tags[0].ID.String())
 	assert.EqualValues(t, "commit", tags[0].Type)
 }
+
+func TestRepository_GetTag(t *testing.T) {
+	bareRepo1Path := filepath.Join(testReposDir, "repo1")
+	bareRepo1, err := OpenRepository(bareRepo1Path)
+	assert.NoError(t, err)
+
+	tag, err := bareRepo1.GetTag("test")
+	assert.NoError(t, err)
+	assert.NotNil(t, tag)
+	assert.EqualValues(t, "test", tag.Name)
+	assert.EqualValues(t, "37991dec2c8e592043f47155ce4808d4580f9123", tag.ID.String())
+	assert.EqualValues(t, "commit", tag.Type)
+}


### PR DESCRIPTION
This will fix https://github.com/go-gitea/gitea/issues/5585

It seems  
```
git show-ref --tags <tag>
```
will not give the right commit id of this tag, but
```
git rev-list -n 1 $TAG
```
will return the right commit id.