### PR TITLE
Fix for bad commitID to show up in error

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -153,13 +153,14 @@ func (repo *Repository) getCommit(id SHA1) (*Commit, error) {
 func (repo *Repository) GetCommit(commitID string) (*Commit, error) {
 	if len(commitID) != 40 {
 		var err error
-		commitID, err = NewCommand("rev-parse", commitID).RunInDir(repo.Path)
+		actualCommitID, err := NewCommand("rev-parse", commitID).RunInDir(repo.Path)
 		if err != nil {
 			if strings.Contains(err.Error(), "unknown revision or path") {
 				return nil, ErrNotExist{commitID, ""}
 			}
 			return nil, err
 		}
+		commitID = actualCommitID
 	}
 	id, err := NewIDFromString(commitID)
 	if err != nil {

--- a/repo_commit_test.go
+++ b/repo_commit_test.go
@@ -26,6 +26,7 @@ func TestRepository_GetCommitBranches(t *testing.T) {
 		{"37991dec2c8e592043f47155ce4808d4580f9123", []string{"master"}},
 		{"95bb4d39648ee7e325106df01a621c530863a653", []string{"branch1", "branch2"}},
 		{"8d92fc957a4d7cfd98bc375f0b7bb189a0d6c9f2", []string{"branch2", "master"}},
+		{"master", []string{"master"}},
 	}
 	for _, testCase := range testCases {
 		commit, err := bareRepo1.GetCommit(testCase.CommitID)

--- a/repo_commit_test.go
+++ b/repo_commit_test.go
@@ -47,3 +47,12 @@ func TestGetTagCommitWithSignature(t *testing.T) {
 	// test that signature is not in message
 	assert.Equal(t, "tag", commit.CommitMessage)
 }
+
+func TestGetCommitWithBadCommitID(t *testing.T) {
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+	bareRepo1, err := OpenRepository(bareRepo1Path)
+	commit, err := bareRepo1.GetCommit("bad_branch")
+	assert.Nil(t, commit)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "object does not exist [id: bad_branch, rel_path: ]")
+}


### PR DESCRIPTION
This error message for a bad commitID makes no sense because when the Error object is created, commitID is always empty since NewCommand() call replaced the given commitID. This makes sure we retain the old commitID until after this block.