### PR TITLE
Fix panic on signed empty commit message (go-gitea/gitea#6292)

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -102,7 +102,7 @@ l:
 				if err == nil && sig != nil {
 					// remove signature from commit message
 					if sigindex == 0 {
-						cm = cm[:0]
+						cm = ""
 					} else {
 						cm = cm[:sigindex-1]
 					}

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -101,7 +101,11 @@ l:
 				sig, err := newGPGSignatureFromCommitline(data, (nextline+1)+sigindex, true)
 				if err == nil && sig != nil {
 					// remove signature from commit message
-					cm = cm[:sigindex-1]
+					if sigindex == 0 {
+						cm = cm[:0]
+					} else {
+						cm = cm[:sigindex-1]
+					}
 					commit.Signature = sig
 				}
 			}


### PR DESCRIPTION
Fix panic on signed empty commit message (go-gitea/gitea#6292)

CommitTrees with empty commit messages such as signed tags will panic when trying to parse their commit message. This PR fixes this.